### PR TITLE
chore: bump go version to 1.22 on crc-builder linux. Fix #25

### DIFF
--- a/crc-builder/oci/Containerfile.linux
+++ b/crc-builder/oci/Containerfile.linux
@@ -5,7 +5,7 @@ ARG TARGETARCH
 
 LABEL org.opencontainers.image.authors="CodeReady Containers <devtools-cdk@redhat.com>"
 
-ENV GO_VERSION 1.21.11
+ENV GO_VERSION 1.22.7
 
 RUN microdnf -y install git make gcc libvirt-devel perl-Digest-SHA xz findutils diffutils tar \
     && curl -Lo /tmp/${GO_VERSION}.tar.gz  https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz \


### PR DESCRIPTION
Fix #25 