### PR TITLE
[crc-support] fix: task using single quotes do not evaluate as expecting

### DIFF
--- a/.github/workflows/crc-support-pusher.yml
+++ b/.github/workflows/crc-support-pusher.yml
@@ -68,7 +68,6 @@ jobs:
           curl -LO "https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_Linux_x86_64.tar.gz"
           tar xvzf "tkn_${TKN_VERSION}_Linux_x86_64.tar.gz" tkn
           ./tkn bundle push ${{ env.image }}-tkn \
-            -f crc-support-installer.yaml \
-            -f crc-support.yaml
+            -f task.yaml
 
       

--- a/crc-support/oci/lib/windows/run.ps1
+++ b/crc-support/oci/lib/windows/run.ps1
@@ -1,23 +1,14 @@
-aBaseURL=''
-aName=''
-aSHAName='sha256sum.txt'
-targetPath=''
-freshEnv='true'
-download='true'
-install='false'
-
-
 param(
     [Parameter(HelpMessage='download base url')]
     $aBaseURL,
     [Parameter(HelpMessage='asset name to be downloaded')]
     $aName,
     [Parameter(HelpMessage='shasumFile file name Default value: sha256sum.txt')]
-    $aSHAName="sha256sum.txt",
+    $aSHAName='sha256sum.txt',
     [Parameter(Mandatory,HelpMessage='target folder for download')]
     $targetPath,
     [Parameter(HelpMessage='force fresh, remove any previous existing instance for crc. Default False')]
-    $forceFresh='false',
+    $freshEnv='false',
     [Parameter(HelpMessage='download if False not download. Default True')]
     $download='true',
     [Parameter(HelpMessage='install after downloading if False not install. Default False')]
@@ -32,7 +23,7 @@ function Force-Fresh-Environment {
         # Wait to be cleared before uninstalling
         Pause-Until-Other-Installations-Finish
         pushd $latestPath
-        Start-Process C:\Windows\System32\msiexec.exe -ArgumentList "/qb /x crc-windows-${arch}.msi /norestart" -wait
+        Start-Process C:\Windows\System32\msiexec.exe -ArgumentList "/qb /x crc-windows-amd64.msi /norestart" -wait
         popd
 	} 
     Start-Process powershell -Verb runAs -ArgumentList "Remove-Item -Recurse -Force $HOME\.crc"
@@ -41,11 +32,11 @@ function Force-Fresh-Environment {
 }
 
 function Require-Download {
-    if (!(Test-Path $downloadItemName)) {
+    if (!(Test-Path $aName)) {
         return $true
     }
-    $hashValue=Get-FileHash $downloadItemName | Select-Object -ExpandProperty Hash
-    $hashMatch=Select-String $shasumFile -Pattern $hashValue -Quiet
+    $hashValue=Get-FileHash $aName | Select-Object -ExpandProperty Hash
+    $hashMatch=Select-String $aSHAName -Pattern $hashValue -Quiet
     return !$hashMatch
 }
 
@@ -59,8 +50,8 @@ function Download ($binaryURL) {
 }
 
 function Check-Download() {
-    $hashValue=Get-FileHash $downloadItemName | Select-Object -ExpandProperty Hash
-    $hashMatch=Select-String $shasumFile -Pattern $hashValue -Quiet
+    $hashValue=Get-FileHash $aName | Select-Object -ExpandProperty Hash
+    $hashMatch=Select-String $aSHAName -Pattern $hashValue -Quiet
     return $hashMatch
 } 
 
@@ -87,10 +78,10 @@ $latestPath="$HOME\OpenshiftLocal\crc\latest"
 # Transform params to bool
 $install = If ($install -eq 'true') {$true} Else {$false}
 $download = If ($download -eq 'true') {$true} Else {$false}
-$forceFresh = If ($forceFresh -eq 'true') {$true} Else {$false}
+$freshEnv = If ($freshEnv -eq 'true') {$true} Else {$false}
 
 # FORCE FRESH
-if ($forceFresh) {
+if ($freshEnv) {
     Force-Fresh-Environment
 }
 

--- a/crc-support/tkn/task.yaml
+++ b/crc-support/tkn/task.yaml
@@ -104,7 +104,7 @@ spec:
         runner="run.ps1"
       fi
       # Path for assets on remote target
-      tPath='/Users/${TARGET_HOST_USERNAME}/OpenshiftLocal'
+      tPath="/Users/${TARGET_HOST_USERNAME}/OpenshiftLocal"
       if [[ $(params.os) == 'linux' ]]; then
         tPath="/home/${TARGET_HOST_USERNAME}/OpenshiftLocal"
       fi
@@ -114,7 +114,7 @@ spec:
         nameArr=(${name//_/ })
         tPath+="/bundle/${nameArr[2]}"
       else
-        tPath+='/crc/$(params.crc-version)'
+        tPath+="/crc/$(params.crc-version)"
       fi
 
 
@@ -125,7 +125,6 @@ spec:
       cmd+="-freshEnv $(params.force-fresh) "
       cmd+="-download $(params.download) "
       cmd+="-install $(params.install) "
-      cmd+="-debug $(params.debug) "
       
       # Exec
       . entrypoint.sh "${cmd}"


### PR DESCRIPTION
This commit fix the issue where the username is not evaluated as part of the target-path giving a wrong value when used with bundles / binaries.