### PR TITLE
[snc-runner] fix: Set decommission task timeout to 45m.

### DIFF
--- a/snc-runner/tkn/tpl/pipeline.tpl.yaml
+++ b/snc-runner/tkn/tpl/pipeline.tpl.yaml
@@ -252,7 +252,7 @@ spec:
         workspace: aws-credentials
       - name: rh-account-secret
         workspace: rh-account-secret
-      timeout: "20m" 
+      timeout: "45m" 
     - name: print-decomission
       when:
         - input: $(params.debug)


### PR DESCRIPTION
From time to time the decomission for arm64 resources is taking more than previous 20 min, so task ended up failing and leftowvers breaks next provisions due to limits. This commit increases the timeout for decomission ensuring there is enough time for remove everything safely