### PR TITLE
[snc-runner] fix MIRROR parameter is not being propagated

### DIFF
--- a/snc-runner/oci/run.sh
+++ b/snc-runner/oci/run.sh
@@ -63,7 +63,7 @@ while [[ $# -gt 0 ]]; do
         shift 
         ;;
         -ocp-mirror)
-        MIRROR="$2"
+        export MIRROR="$2"
         shift 
         shift 
         ;;


### PR DESCRIPTION
once ocp-mirror is set, it defines MIRROR env var, but without export it, is not passed to executed scripts