### PR TITLE
[snc-runner] Fix ocp-mirror parsing from ocp-index-url

### DIFF
--- a/snc-runner/tkn/tpl/pipeline.tpl.yaml
+++ b/snc-runner/tkn/tpl/pipeline.tpl.yaml
@@ -136,7 +136,8 @@ spec:
               #!/bin/sh
               echo -n $RANDOM$RANDOM | tee $(results.correlation.path)
               index_url=$(params.ocp-index-url)
-              echo -n ${index_url##*/} | tee $(results.ocp-version.path)
+              version=${index_url##*/}
+              echo -n ${version} | tee $(results.ocp-version.path)
               echo -n ${index_url/\/$version/''} | tee $(results.ocp-mirror.path)
       params:
         - name: ocp-index-url


### PR DESCRIPTION
script to extract ocp-mirror miss $version env to remove from index-url to get mirror-url