### PR TITLE
fix(script): Move $ErrorActionPreference = 'Stop' below param block (#57)

### DIFF
--- a/crc-builder/oci/lib/windows/run.ps1
+++ b/crc-builder/oci/lib/windows/run.ps1
@@ -1,4 +1,3 @@
-$ErrorActionPreference = "Stop"
 # Script to be executed on windows machine to build a crc windows installer
 # and upload it to s3 compatible storage
 param(
@@ -17,10 +16,13 @@ param(
     [Parameter(Mandatory,HelpMessage='remote s3 credential ')]
     $datalakeAcessKey,
     [Parameter(Mandatory,HelpMessage='remote s3 credential')]
-    $datalakeSecretKey
+    $datalakeSecretKey,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $RemainingArgs
 )
 
-# Upload content to S3 compatible 
+$ErrorActionPreference = "Stop"
+# Upload content to S3 compatible
 # $1 remote path
 # $2 local path to be uploaded
 function S3-Upload($uploadPath, $localPath) {


### PR DESCRIPTION
 ## Description

Fix #57 

- Resolved a syntax error caused by placing the $ErrorActionPreference = 'Stop' statement above the param block.
- Reordered the script to ensure proper execution and adhere to PowerShell conventions.

I've tested it on windows using test script (see https://github.com/crc-org/ci-definitions/issues/57#issuecomment-2705998225)