### PR TITLE
[crc-support]fix removing old folder function

### DIFF
--- a/crc-support/oci/lib/unix/run.sh
+++ b/crc-support/oci/lib/unix/run.sh
@@ -127,8 +127,16 @@ fi
 if [[ $delete == 'true' ]]; then
     cd ..
     ls -lh
-    echo "removing 10 days ago folders"
-    find . -maxdepth 1 -type d -mtime +10 -exec rm -r {} \;
+    echo "removing 21 days ago folders"
+    for dir in */; do
+        # find the latest changed file
+        latest_file=`ls -t $dir | head -n 1`
+        # Check if the latest file is older than 21 days
+        if find $dir/$latest_file -type f -mtime +21 | grep -q .; then
+            echo "removing  $dir"
+            rm -r $dir
+        fi
+    done
     ls -lh
 fi
 

--- a/crc-support/oci/lib/windows/run.ps1
+++ b/crc-support/oci/lib/windows/run.ps1
@@ -113,8 +113,19 @@ if ($download) {
 if ($delete) {
     cd ..
     ls
-    Write-Host "removing 10 days ago folders "
-    Get-ChildItem -Path . -Directory | Where-Object {($_.LastWriteTime -lt (Get-Date).AddDays(-10))} | Remove-Item -Recurse -Force
+    Write-Host "removing 21 days ago folders "
+    Get-ChildItem -Directory | ForEach-Object {
+        $dir = $_.FullName
+
+        # Find the latest modified file in the directory
+        $latest_file = Get-ChildItem -Path $dir -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+
+        # Check if the latest file is older than 21 days
+        if ($latest_file.LastWriteTime -lt (Get-Date).AddDays(-21)) {
+            Write-Output "Removing directory: $dir"
+            Remove-Item -Path $dir -Recurse -Force
+        }
+    }
     ls
     pushd $targetPath
 }


### PR DESCRIPTION
The bundle/binary was re-downloaded but content not change, it folder is considered as not modified. The deleting older folder function will remove these folders. Re-create the folder to ensure its date always the latest.

## Summary by Sourcery

Modify target path handling to ensure the folder is always recreated with the latest timestamp

Bug Fixes:
- Resolve issue with stale directory timestamps when re-downloading bundles or binaries without content changes

Enhancements:
- Implement explicit removal and recreation of target path directory to guarantee the most recent timestamp