### PR TITLE
[reportportal] move reporportal task to ci-definition

### DIFF
--- a/.github/workflows/reportportal-builder.yaml
+++ b/.github/workflows/reportportal-builder.yaml
@@ -1,0 +1,82 @@
+name: reportportal-builder
+
+on:
+  push:
+    tags: [ 'reportportal-v*' ]       
+  pull_request:
+    branches: [ main ]
+    paths: ['Makefile', 'reportportal/**', '.github\/workflows\/reportportal*' ]
+      
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build image for PR
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          REPORTPORTAL: ghcr.io/crc-org/ci-reportportal
+          REPORTPORTAL_V: pr-${{ github.event.number }}
+        run: |
+          make reportportal-oci-build
+          make reportportal-oci-save
+          echo "image=${REPORTPORTAL}:${REPORTPORTAL_V}" >> "$GITHUB_ENV"
+  
+      - name: Build image for Release
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          make reportportal-oci-build
+          make reportportal-oci-save
+          echo "image=$(sed -n 1p reportportal/release-info):v$(sed -n 2p reportportal/release-info)" >> "$GITHUB_ENV"
+
+      - name: Create image metadata
+        run: |
+          echo ${{ env.image }} > reportportal-image
+          echo ${{ github.event_name }} > reportportal-build-event
+  
+      - name: Upload reportportal
+        uses: actions/upload-artifact@v4
+        with:
+          name: reportportal
+          path: reportportal*
+
+  tkn-check:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Template tkn for PR
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          REPORTPORTAL: ghcr.io/crc-org/ci-reportportal
+          REPORTPORTAL_V: pr-${{ github.event.number }}
+        run: |
+          make reportportal-tkn-create
+
+      - name: Check tkn specs
+        run: |
+          if [[ ! -f reportportal/tkn/import.yaml ]]; then 
+            exit 1
+          fi
+          # Check if version is in sync
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1
+    
+        # https://docs.openshift.com/pipelines/1.15/about/op-release-notes.html
+      - name: Deploy min supported tekton version
+        run: kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.44.5/release.yaml
+    
+      - name: Deploy tasks
+        run: |
+          kubectl apply -f reportportal/tkn/import.yaml
+
+      - name: Upload reportportal-tkn
+        uses: actions/upload-artifact@v4
+        with:
+          name: reportportal-tkn
+          path: reportportal/tkn/import.yaml

--- a/.github/workflows/reportportal-pusher.yaml
+++ b/.github/workflows/reportportal-pusher.yaml
@@ -1,0 +1,69 @@
+name: reportportal-pusher
+
+on:
+  workflow_run:
+    workflows: [ 'reportportal-builder' ]
+    types:
+      - completed
+  
+jobs:
+  push:
+    name: push
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download reportportal assets
+        uses: actions/download-artifact@v4
+        with:
+          name: reportportal
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Get reportportal build informaiton
+        run: |
+          echo "source_event=$(cat reportportal-build-event)" >> "$GITHUB_ENV"
+          echo "image=$(cat reportportal-image)" >> "$GITHUB_ENV"
+
+      - name: Log in to ghcr.io
+        if: ${{ env.source_event == 'pull_request' }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in quay.io
+        if: ${{ env.source_event == 'push' }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_PASSWORD }}
+
+      - name: Push reportportal
+        run: |
+          # Load 
+          podman load -i reportportal.tar 
+          # Push
+          podman push ${{ env.image }}
+
+      - name: Download reportportal-tkn assets
+        uses: actions/download-artifact@v4
+        with:
+          name: reportportal-tkn
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Push reportportal-tkn
+        env:
+          TKN_VERSION: '0.37.0'
+        run: |
+          curl -LO "https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_Linux_x86_64.tar.gz"
+          tar xvzf "tkn_${TKN_VERSION}_Linux_x86_64.tar.gz" tkn
+          ./tkn bundle push ${{ env.image }}-tkn \
+            -f import.yaml
+
+      

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,6 @@ endif
 	$(TOOLS_BINDIR)/tkn bundle push $(IMAGE)-tkn \
 		-f crc-support/tkn/task.yaml
 
-
 #### s3-uploader ####
 
 .PHONY: s3-uploader-oci-build s3-uploader-tkn-create
@@ -175,3 +174,33 @@ s3-uploader-oci-push:
 
 s3-uploader-tkn-create:
 	$(call tkn_template,$(S3_IMAGE),$(S3_VERSION),s3-uploader,task)
+
+
+#### reportportal ####
+
+.PHONY: reportportal-oci-build reportportal-oci-save reportportal-oci-load reportportal-oci-push reportportal-tkn-create reportportal-tkn-push
+
+REPORTPORTAL ?= $(shell sed -n 1p reportportal/release-info)
+REPORTPORTAL_V ?= v$(shell sed -n 2p reportportal/release-info)
+REPORTPORTAL_SAVE ?= reportportal
+
+reportportal-oci-build:CONTEXT=reportportal/oci
+reportportal-oci-build: MANIFEST=$(REPORTPORTAL):$(REPORTPORTAL_V)
+reportportal-oci-build:
+	${CONTAINER_MANAGER} build -t $(MANIFEST) -f $(CONTEXT)/Containerfile $(CONTEXT)
+
+
+reportportal-oci-save: MANIFEST=$(REPORTPORTAL):$(REPORTPORTAL_V)
+reportportal-oci-save:
+	${CONTAINER_MANAGER} save -o $(REPORTPORTAL_SAVE).tar $(MANIFEST)
+
+reportportal-oci-load:
+	${CONTAINER_MANAGER} load -i $(REPORTPORTAL_SAVE).tar 
+
+reportportal-oci-push: MANIFEST=$(REPORTPORTAL):$(REPORTPORTAL_V)
+reportportal-oci-push:
+	${CONTAINER_MANAGER} push $(MANIFEST)
+
+reportportal-tkn-create:
+	$(call tkn_template,$(REPORTPORTAL),$(REPORTPORTAL_V),reportportal,import)
+

--- a/reportportal/oci/Containerfile
+++ b/reportportal/oci/Containerfile
@@ -1,0 +1,11 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal
+
+LABEL org.opencontainers.image.authors="CodeReady Containers <devtools-cdk@redhat.com>"
+
+ENV TKN_CLI https://github.com/tektoncd/cli/releases/download/v0.38.1/tkn_0.38.1_Linux_x86_64.tar.gz
+
+RUN microdnf install -y openssh-clients sshpass zip bash jq findutils python3 tar\
+    && curl -LO "${TKN_CLI}" \
+    && tar -xzvf tkn_0.38.1_Linux_x86_64.tar.gz -C /usr/local/bin/
+
+COPY trans-log-xml.py /opt/

--- a/reportportal/oci/trans-log-xml.py
+++ b/reportportal/oci/trans-log-xml.py
@@ -1,0 +1,65 @@
+import re
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
+import sys
+
+def log_to_xml_with_steps(log_file, xml_file):
+    # Create the root element for XML
+    root = ET.Element("testsuites", name="pipeline-logs")
+    suit_element = ET.SubElement(root, "testsuite", name='piplinerun')
+    case_element = ET.SubElement(suit_element, "testcase",name='logs')
+    root.set("tests", "1")
+    root.set("failures", "0")
+    root.set("status", "passed")
+
+    step_element = None
+    task_element = None
+    # Open the log file and process each line
+    with open(log_file, "r") as file:
+        task=''
+        step=''
+        log=''
+        for line in file:
+
+            # Check if the line indicates a new step
+            step_match = re.match(r"^\[", line)
+            if step_match:
+                # If a new step is detected, create a new <step> element
+                line_contents=line.split("]")
+                task_info=line_contents[0].split(":")
+                task_name=task_info[0].removeprefix('[')
+                step_name=task_info[1].removeprefix(' ')
+                content=line_contents[1]
+                if (task_name != task) | (step_name != step):
+                    if step_element != None:
+                        infos = "["+ task + ":" + step +"]"+"\n"
+                        log=infos+log
+                        ET.SubElement(step_element, "system-out").text = log.strip()
+                        log=""
+                    if task_name != task:
+                        task_element = ET.SubElement(case_element, "task", name=task_name)
+                    step_element = ET.SubElement(task_element, "step", name=step_name)
+                log=log+content
+                task=task_name
+                step=step_name
+            elif log != '':
+                log=log+line
+        ET.SubElement(step_element, "system-out").text = log.strip()    
+
+    # Write the XML tree to a file
+    xml_str = ET.tostring(root, encoding="utf-8").decode("utf-8")
+    xml_str = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]', '', xml_str)
+    pretty_xml = minidom.parseString(xml_str).toprettyxml(indent="  ")
+    with open(xml_file, "w") as f:
+        f.write(pretty_xml)
+
+    print(f"Log file with steps converted to XML report: {xml_file}")
+
+
+if len(sys.argv) < 2:
+    print("Usage: python example.py <param1> <param2>")
+    sys.exit(1)
+
+log_file = sys.argv[1]  # First parameter
+xml_file = sys.argv[2]
+log_to_xml_with_steps(log_file, xml_file)

--- a/reportportal/release-info
+++ b/reportportal/release-info
@@ -1,0 +1,2 @@
+quay.io/crc-org/reportportal
+1.0.0

--- a/reportportal/tkn/import.yaml
+++ b/reportportal/tkn/import.yaml
@@ -1,0 +1,168 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: reportportal-import
+  labels:
+    app.kubernetes.io/version: "v1.0.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.24.x"
+    tekton.dev/categories: data
+    tekton.dev/tags: "data, results"
+    tekton.dev/displayName: "report portal import"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: |
+    Task to import junit results into report portal
+  
+  params:
+  - name: secret-reportportal
+    description: |
+      ocp secret holding the report portal credentials. Secret should be accessible to this task.
+
+      ---
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: XXX
+      type: Opaque
+      data:
+        token: XXXX
+        url: XXXX
+        project: XXXX
+    default: reportportal-crc
+  - name: pvc
+    description: The persistentVolumeClaim name that contains the xml file to be imported to reportportal
+    default: pipelines-data
+  - name: results-id
+    description: Identifier for the results. Typically will include metadata about the environment or the product
+  - name: results-wsstorage-path
+    description: path within the storage workspace for the results file to be uploaded
+  - name: launch-attributes
+    description: |
+      The attributes for the launch, will show as tag in reportportal. 
+      The value format is 
+      {"attributes": [{"key":"crc-version","value":"20240926"}, {"key":"bundle-version","value":"4.17.0-rc.5"}]}
+  - name: launch-description
+    description: The description for the launch.
+    default: nightly-run
+  # Control
+  - name: debug
+    description: debug the task cmds
+    default: 'false' 
+  - name: upload-log
+    default: 'false'
+    description: |
+      whether upload the current pipelinerun logs. 
+      If true, the task will gather current pipeline-run logs to xml, then upload to reportportal.
+      So recommend put this task in Final block of pipeline. 
+  - name: pipelinerunName
+    default: $(context.pipelineRun.name)
+    description: the pipelinerun name which log be uploaded to reportportal 
+
+  steps:
+  - name: import
+    image: quay.io/crc-org/reportportal:v1.0.0 #v0.0.5
+    imagePullPolicy: Always
+    volumeMounts:
+      - name: reportportal-credentials
+        mountPath: /opt/reportportal-credentials
+      - name: storage
+        mountPath: /opt/storage
+    script: |
+      #!/bin/sh
+      set -e
+      set -x
+
+      # If debug add verbosity
+      if [[ $(params.debug) == "true" ]]; then
+        set -exuo pipefail
+      fi
+
+      if [[ $(params.upload-log) == 'true' ]]; then
+        echo $(params.pipelinerunName)
+        tkn pipelinerun list | grep $(params.pipelinerunName)
+        if [[ $? == 0 ]]; then
+          tkn pipelinerun logs $(params.pipelinerunName) > pipelinerun.log
+          logPath=pipelinerun.log
+          xmlPath=pipelineLog.xml
+          python3 /opt/trans-log-xml.py $logPath $xmlPath
+          ls -lh
+        else 
+          echo "no pipelinerun $(params.pipelinerunName) found"
+        fi
+      fi
+
+      failFlag='false'
+      # Prepare results
+      if find "/opt/storage/$(params.results-wsstorage-path)" -maxdepth 1 -name "*.xml" -print -quit | grep -q .; then
+        cp /opt/storage/$(params.results-wsstorage-path)/*.xml .
+      else
+        failFlag='true'
+      fi
+      # remove the xml file if its size is 0 byte
+      # find "/opt/storage/$(params.results-wsstorage-path)" -type f -name "*.xml" -size 0 -exec rm {} \;
+
+
+      # Compress
+      if [[ $failFlag == 'true' ]]; then
+        fileName="fail-pipelinerun"
+      else
+        fileName=$(params.results-id)
+      fi
+
+      zip "$fileName.zip" *.xml
+      # Import
+      url=$(cat /opt/reportportal-credentials/url)
+      token=$(cat /opt/reportportal-credentials/token)
+      project=$(cat /opt/reportportal-credentials/project)
+      upload=`curl -k -X POST "${url}/api/v1/${project}/launch/import" \
+          -H "accept: */*" -H "Content-Type: multipart/form-data" \
+          -H "Authorization: bearer ${token}" \
+          -F "file=@$fileName.zip"`
+      uuid=`echo ${upload#*= } | cut -d " " -f1`
+      getid=`curl -k -X GET "${url}/api/v1/${project}/launch/uuid/${uuid}" \
+          -H "accept: */*" -H  "Authorization: bearer ${token}"`
+      launchId=`echo $getid | jq .id`
+      if [[ $failFlag != 'true' ]]; then
+        curl -k -X PUT "${url}/api/v1/${project}/launch/${launchId}/update" \
+            -H "accept: */*" -H "Content-Type: application/json" \
+            -H "Authorization: bearer ${token}" \
+            -d '{"description": "$(params.launch-description)"}'
+        curl -k -X PUT "${url}/api/v1/${project}/launch/${launchId}/update" \
+            -H "accept: */*" -H "Content-Type: application/json" \
+            -H "Authorization: bearer ${token}" \
+            -d '$(params.launch-attributes)'
+      else
+        curl -k -X PUT "${url}/api/v1/${project}/launch/${launchId}/update" \
+            -H "accept: */*" -H "Content-Type: application/json" \
+            -H "Authorization: bearer ${token}" \
+            -d '{"description": "$(params.results-id)"}'
+      fi
+
+      # delete the folder in pvc
+      path=$(params.results-wsstorage-path)
+      IFS='/' read -ra folder <<< "$path"
+      if [ -d "/opt/storage/$folder" ]; then
+        ls /opt/storage/$folder
+        rm -r /opt/storage/$folder
+      fi
+
+    resources:      
+      requests:
+        memory: "100Mi"
+        cpu: "50m"
+      limits:
+        memory: "200Mi"
+        cpu: "100m"
+
+  volumes:
+    - name: storage
+      description: storage volume where to find the results to be imported
+      persistentVolumeClaim:
+        claimName: $(params.pvc)
+    - name: reportportal-credentials
+      secret:
+        secretName: $(params.secret-reportportal)
+    
+    

--- a/reportportal/tkn/tpl/import.tpl.yaml
+++ b/reportportal/tkn/tpl/import.tpl.yaml
@@ -1,0 +1,168 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: reportportal-import
+  labels:
+    app.kubernetes.io/version: "cversion"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.24.x"
+    tekton.dev/categories: data
+    tekton.dev/tags: "data, results"
+    tekton.dev/displayName: "report portal import"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: |
+    Task to import junit results into report portal
+  
+  params:
+  - name: secret-reportportal
+    description: |
+      ocp secret holding the report portal credentials. Secret should be accessible to this task.
+
+      ---
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: XXX
+      type: Opaque
+      data:
+        token: XXXX
+        url: XXXX
+        project: XXXX
+    default: reportportal-crc
+  - name: pvc
+    description: The persistentVolumeClaim name that contains the xml file to be imported to reportportal
+    default: pipelines-data
+  - name: results-id
+    description: Identifier for the results. Typically will include metadata about the environment or the product
+  - name: results-wsstorage-path
+    description: path within the storage workspace for the results file to be uploaded
+  - name: launch-attributes
+    description: |
+      The attributes for the launch, will show as tag in reportportal. 
+      The value format is 
+      {"attributes": [{"key":"crc-version","value":"20240926"}, {"key":"bundle-version","value":"4.17.0-rc.5"}]}
+  - name: launch-description
+    description: The description for the launch.
+    default: nightly-run
+  # Control
+  - name: debug
+    description: debug the task cmds
+    default: 'false' 
+  - name: upload-log
+    default: 'false'
+    description: |
+      whether upload the current pipelinerun logs. 
+      If true, the task will gather current pipeline-run logs to xml, then upload to reportportal.
+      So recommend put this task in Final block of pipeline. 
+  - name: pipelinerunName
+    default: $(context.pipelineRun.name)
+    description: the pipelinerun name which log be uploaded to reportportal 
+
+  steps:
+  - name: import
+    image: cimage:cversion #v0.0.5
+    imagePullPolicy: Always
+    volumeMounts:
+      - name: reportportal-credentials
+        mountPath: /opt/reportportal-credentials
+      - name: storage
+        mountPath: /opt/storage
+    script: |
+      #!/bin/sh
+      set -e
+      set -x
+
+      # If debug add verbosity
+      if [[ $(params.debug) == "true" ]]; then
+        set -exuo pipefail
+      fi
+
+      if [[ $(params.upload-log) == 'true' ]]; then
+        echo $(params.pipelinerunName)
+        tkn pipelinerun list | grep $(params.pipelinerunName)
+        if [[ $? == 0 ]]; then
+          tkn pipelinerun logs $(params.pipelinerunName) > pipelinerun.log
+          logPath=pipelinerun.log
+          xmlPath=pipelineLog.xml
+          python3 /opt/trans-log-xml.py $logPath $xmlPath
+          ls -lh
+        else 
+          echo "no pipelinerun $(params.pipelinerunName) found"
+        fi
+      fi
+
+      failFlag='false'
+      # Prepare results
+      if find "/opt/storage/$(params.results-wsstorage-path)" -maxdepth 1 -name "*.xml" -print -quit | grep -q .; then
+        cp /opt/storage/$(params.results-wsstorage-path)/*.xml .
+      else
+        failFlag='true'
+      fi
+      # remove the xml file if its size is 0 byte
+      # find "/opt/storage/$(params.results-wsstorage-path)" -type f -name "*.xml" -size 0 -exec rm {} \;
+
+
+      # Compress
+      if [[ $failFlag == 'true' ]]; then
+        fileName="fail-pipelinerun"
+      else
+        fileName=$(params.results-id)
+      fi
+
+      zip "$fileName.zip" *.xml
+      # Import
+      url=$(cat /opt/reportportal-credentials/url)
+      token=$(cat /opt/reportportal-credentials/token)
+      project=$(cat /opt/reportportal-credentials/project)
+      upload=`curl -k -X POST "${url}/api/v1/${project}/launch/import" \
+          -H "accept: */*" -H "Content-Type: multipart/form-data" \
+          -H "Authorization: bearer ${token}" \
+          -F "file=@$fileName.zip"`
+      uuid=`echo ${upload#*= } | cut -d " " -f1`
+      getid=`curl -k -X GET "${url}/api/v1/${project}/launch/uuid/${uuid}" \
+          -H "accept: */*" -H  "Authorization: bearer ${token}"`
+      launchId=`echo $getid | jq .id`
+      if [[ $failFlag != 'true' ]]; then
+        curl -k -X PUT "${url}/api/v1/${project}/launch/${launchId}/update" \
+            -H "accept: */*" -H "Content-Type: application/json" \
+            -H "Authorization: bearer ${token}" \
+            -d '{"description": "$(params.launch-description)"}'
+        curl -k -X PUT "${url}/api/v1/${project}/launch/${launchId}/update" \
+            -H "accept: */*" -H "Content-Type: application/json" \
+            -H "Authorization: bearer ${token}" \
+            -d '$(params.launch-attributes)'
+      else
+        curl -k -X PUT "${url}/api/v1/${project}/launch/${launchId}/update" \
+            -H "accept: */*" -H "Content-Type: application/json" \
+            -H "Authorization: bearer ${token}" \
+            -d '{"description": "$(params.results-id)"}'
+      fi
+
+      # delete the folder in pvc
+      path=$(params.results-wsstorage-path)
+      IFS='/' read -ra folder <<< "$path"
+      if [ -d "/opt/storage/$folder" ]; then
+        ls /opt/storage/$folder
+        rm -r /opt/storage/$folder
+      fi
+
+    resources:      
+      requests:
+        memory: "100Mi"
+        cpu: "50m"
+      limits:
+        memory: "200Mi"
+        cpu: "100m"
+
+  volumes:
+    - name: storage
+      description: storage volume where to find the results to be imported
+      persistentVolumeClaim:
+        claimName: $(params.pvc)
+    - name: reportportal-credentials
+      secret:
+        secretName: $(params.secret-reportportal)
+    
+    


### PR DESCRIPTION
https://github.com/crc-org/ci-definitions/issues/63

## Summary by Sourcery

Move ReportPortal task to CI definition, adding support for importing test results and pipeline logs to ReportPortal

New Features:
- Add Tekton task for importing test results and pipeline logs to ReportPortal
- Create a Python script to convert pipeline logs to XML format for ReportPortal import

CI:
- Add Makefile targets for ReportPortal OCI image and Tekton task management
- Introduce ReportPortal-specific CI workflow components

Deployment:
- Create Containerfile for ReportPortal support image
- Add release-info file for versioning ReportPortal support components