### PR TITLE
[s3-uploader]migrate s3-uploader to ci-definations

### DIFF
--- a/.github/workflows/s3-uploader-builder.yaml
+++ b/.github/workflows/s3-uploader-builder.yaml
@@ -1,0 +1,89 @@
+name: s3-uploader-builder
+
+on:
+  push:
+    tags: [ 's3-uploader-v*' ]       
+  pull_request:
+    branches: [ main ]
+    paths: ['Makefile', 's3-uploader/**', '.github\/workflows\/s3-uploader*' ]
+      
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build image for PR
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          S3_IMAGE: ghcr.io/crc-org/ci-s3-uploader
+          S3_VERSION: pr-${{ github.event.number }}
+        run: |
+          make s3-uploader-oci-build
+          make s3-uploader-oci-save
+          echo "image=${S3_IMAGE}:${S3_VERSION}" >> "$GITHUB_ENV"
+  
+      - name: Build image for Release
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          make s3-uploader-oci-build
+          make s3-uploader-oci-save
+          echo "image=$(sed -n 1p s3-uploader/release-info):v$(sed -n 2p s3-uploader/release-info)" >> "$GITHUB_ENV"
+
+      - name: Create image metadata
+        run: |
+          echo ${{ env.image }} > s3-uploader-image
+          echo ${{ github.event_name }} > s3-uploader-build-event
+  
+      - name: Upload s3-uploader
+        uses: actions/upload-artifact@v4
+        with:
+          name: s3-uploader
+          path: s3-uploader*
+
+  tkn-check:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Template tkn for PR
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          S3_IMAGE: ghcr.io/crc-org/ci-s3-uploader
+          S3_VERSION: pr-${{ github.event.number }}
+        run: |
+          make s3-uploader-tkn-create
+
+      - name: Check tkn specs
+        run: |
+          if [[ ! -f s3-uploader/tkn/task.yaml ]]; then 
+            exit 1
+          fi
+          # Check if version is in sync
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1
+    
+        # https://docs.openshift.com/pipelines/1.15/about/op-release-notes.html
+      - name: Deploy min supported tekton version
+        run: kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.44.5/release.yaml
+    
+      - name: Deploy tasks
+        run: |
+          kubectl apply -f s3-uploader/tkn/task.yaml
+
+      - name: Upload s3-uploader-tkn
+        uses: actions/upload-artifact@v4
+        with:
+          name: s3-uploader-tkn
+          path: s3-uploader/tkn/task.yaml
+
+
+
+
+
+
+     

--- a/.github/workflows/s3-uploader-pusher.yaml
+++ b/.github/workflows/s3-uploader-pusher.yaml
@@ -1,0 +1,69 @@
+name: s3-uploader-pusher
+
+on:
+  workflow_run:
+    workflows: [ 's3-uploader-builder' ]
+    types:
+      - completed
+  
+jobs:
+  push:
+    name: push
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download s3-uploader assets
+        uses: actions/download-artifact@v4
+        with:
+          name: s3-uploader
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Get s3-uploader build informaiton
+        run: |
+          echo "source_event=$(cat s3-uploader-build-event)" >> "$GITHUB_ENV"
+          echo "image=$(cat s3-uploader-image)" >> "$GITHUB_ENV"
+
+      - name: Log in to ghcr.io
+        if: ${{ env.source_event == 'pull_request' }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in quay.io
+        if: ${{ env.source_event == 'push' }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_PASSWORD }}
+
+      - name: Push s3-uploader
+        run: |
+          # Load 
+          podman load -i s3-uploader.tar  
+          # Push
+          podman push ${{ env.image }}
+
+      - name: Download s3-uploader-tkn assets
+        uses: actions/download-artifact@v4
+        with:
+          name: s3-uploader-tkn
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Push s3-uploader-tkn
+        env:
+          TKN_VERSION: '0.37.0'
+        run: |
+          curl -LO "https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_Linux_x86_64.tar.gz"
+          tar xvzf "tkn_${TKN_VERSION}_Linux_x86_64.tar.gz" tkn
+          ./tkn bundle push ${{ env.image }}-tkn \
+            -f task.yaml
+
+      

--- a/Makefile
+++ b/Makefile
@@ -150,3 +150,28 @@ ifndef IMAGE
 endif
 	$(TOOLS_BINDIR)/tkn bundle push $(IMAGE)-tkn \
 		-f crc-support/tkn/task.yaml
+
+
+#### s3-uploader ####
+
+.PHONY: s3-uploader-oci-build s3-uploader-tkn-create
+
+S3_IMAGE ?= $(shell sed -n 1p s3-uploader/release-info)
+S3_VERSION ?= v$(shell sed -n 2p s3-uploader/release-info)
+S3_SAVE ?= s3-uploader
+
+s3-uploader-oci-build: CONTEXT=s3-uploader/oci
+s3-uploader-oci-build: MANIFEST=$(S3_IMAGE):$(S3_VERSION)
+s3-uploader-oci-build:
+	${CONTAINER_MANAGER} build -t $(MANIFEST) -f $(CONTEXT)/Containerfile $(CONTEXT)
+
+s3-uploader-oci-save:  MANIFEST=$(S3_IMAGE):$(S3_VERSION)
+s3-uploader-oci-save:
+	${CONTAINER_MANAGER} save -o $(S3_SAVE).tar $(MANIFEST)
+
+s3-uploader-oci-push: MANIFEST=$(S3_IMAGE):$(S3_VERSION)
+s3-uploader-oci-push:
+	${CONTAINER_MANAGER} push $(MANIFEST)
+
+s3-uploader-tkn-create:
+	$(call tkn_template,$(S3_IMAGE),$(S3_VERSION),s3-uploader,task)

--- a/s3-uploader/oci/Containerfile
+++ b/s3-uploader/oci/Containerfile
@@ -1,0 +1,20 @@
+# ubi 9.5-1742914212
+FROM registry.access.redhat.com/ubi9-minimal@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869
+
+LABEL org.opencontainers.image.authors="CodeReady Containers <devtools-cdk@redhat.com>"
+
+ENV AWS_CLI_VERSION 2.18.15
+ENV AWS_CLI_URL https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip
+
+RUN microdnf install -y openssh-clients sshpass unzip zip bash jq findutils wget \
+    && curl ${AWS_CLI_URL} -o awscliv2.zip \
+    && unzip awscliv2.zip \
+    && ./aws/install \
+    && microdnf clean all \
+  	&& rm -rf /var/cache/yum \
+    && mkdir /home/1001 \
+    && chown -R 1001:0 /home/1001 \
+    && chmod -R g=u /home/1001
+
+USER 1001
+ENV HOME /home/1001

--- a/s3-uploader/release-info
+++ b/s3-uploader/release-info
@@ -1,0 +1,2 @@
+quay.io/crc-org/s3-uploader
+1.0.0

--- a/s3-uploader/tkn/task.yaml
+++ b/s3-uploader/tkn/task.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: s3-uploader
+  labels:
+    app.kubernetes.io/version: "v1.0.0"
+    redhat.com/product: openshift-local
+    dev.lifecycle.io/phase: testing
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: "openshift-local"
+    tekton.dev/tags: "openshift-local, testing"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This task will upload test results to aws s3
+
+  volumes:
+    - name: aws-credentials
+      secret:
+        secretName: $(params.aws-credentials)
+    - name: storage
+      persistentVolumeClaim:
+        claimName: $(params.pvc)
+  
+  params:
+    - name: aws-credentials
+      description: |
+        ocp secret holding the aws credentials. Secret should be accessible to this task.
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-${name}
+          labels:
+            app.kubernetes.io/component: ${name}
+            app.kubernetes.io/part-of: qe-platform
+        type: Opaque
+        data:
+          access-key: ${access_key}
+          secret-key: ${secret_key}
+          region: ${region}
+      default: aws-crcqe-bot
+    - name: pvc
+      default: pipelines-data
+    - name: ws-output-path
+      description: the path inside the pvc that to be uploaded to s3
+    - name: qe-workspace-subpath
+    - name: s3-bucket
+    - name: s3-path
+      description: Path inside the bucket to upload the assets i.e folder...nightly/crc/$date/linux-arm64
+
+  results:
+    - name: e2e-junit-url
+    - name: integration-junit-url
+    
+  steps:
+    - name: uploader
+      image: quay.io/crc-org/s3-uploader:v1.0.0
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: aws-credentials
+          mountPath: /opt/aws-credentials
+        - name: storage
+          mountPath: /opt/storage
+      script: |
+        #!/bin/sh
+        mkdir -p /home/1001/.aws
+        cat <<EOF > /home/1001/.aws/credentials
+        [default]
+        aws_access_key_id     = $(cat /opt/aws-credentials/access-key)
+        aws_secret_access_key = $(cat /opt/aws-credentials/secret-key)
+        EOF
+        cat <<EOF > /home/1001/.aws/config
+        [default]
+        region = $(cat /opt/aws-credentials/region)
+        EOF
+
+        aws s3 cp --recursive /opt/storage/$(params.ws-output-path)/$(params.qe-workspace-subpath)/ s3://$(params.s3-bucket)/$(params.s3-path)
+
+        echo -n "https://$(params.s3-bucket).s3.amazonaws.com/$(params.s3-path)/e2e-junit.xml" | tee $(results.e2e-junit-url.path)
+        echo -n "https://$(params.s3-bucket).s3.amazonaws.com/$(params.s3-path)/integration-junit.xml" | tee $(results.integration-junit-url.path)        

--- a/s3-uploader/tkn/tpl/task.tpl.yaml
+++ b/s3-uploader/tkn/tpl/task.tpl.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: s3-uploader
+  labels:
+    app.kubernetes.io/version: "cversion"
+    redhat.com/product: openshift-local
+    dev.lifecycle.io/phase: testing
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: "openshift-local"
+    tekton.dev/tags: "openshift-local, testing"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This task will upload test results to aws s3
+
+  volumes:
+    - name: aws-credentials
+      secret:
+        secretName: $(params.aws-credentials)
+    - name: storage
+      persistentVolumeClaim:
+        claimName: $(params.pvc)
+  
+  params:
+    - name: aws-credentials
+      description: |
+        ocp secret holding the aws credentials. Secret should be accessible to this task.
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-${name}
+          labels:
+            app.kubernetes.io/component: ${name}
+            app.kubernetes.io/part-of: qe-platform
+        type: Opaque
+        data:
+          access-key: ${access_key}
+          secret-key: ${secret_key}
+          region: ${region}
+      default: aws-crcqe-bot
+    - name: pvc
+      default: pipelines-data
+    - name: ws-output-path
+      description: the path inside the pvc that to be uploaded to s3
+    - name: qe-workspace-subpath
+    - name: s3-bucket
+    - name: s3-path
+      description: Path inside the bucket to upload the assets i.e folder...nightly/crc/$date/linux-arm64
+
+  results:
+    - name: e2e-junit-url
+    - name: integration-junit-url
+    
+  steps:
+    - name: uploader
+      image: cimage:cversion
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: aws-credentials
+          mountPath: /opt/aws-credentials
+        - name: storage
+          mountPath: /opt/storage
+      script: |
+        #!/bin/sh
+        mkdir -p /home/1001/.aws
+        cat <<EOF > /home/1001/.aws/credentials
+        [default]
+        aws_access_key_id     = $(cat /opt/aws-credentials/access-key)
+        aws_secret_access_key = $(cat /opt/aws-credentials/secret-key)
+        EOF
+        cat <<EOF > /home/1001/.aws/config
+        [default]
+        region = $(cat /opt/aws-credentials/region)
+        EOF
+
+        aws s3 cp --recursive /opt/storage/$(params.ws-output-path)/$(params.qe-workspace-subpath)/ s3://$(params.s3-bucket)/$(params.s3-path)
+
+        echo -n "https://$(params.s3-bucket).s3.amazonaws.com/$(params.s3-path)/e2e-junit.xml" | tee $(results.e2e-junit-url.path)
+        echo -n "https://$(params.s3-bucket).s3.amazonaws.com/$(params.s3-path)/integration-junit.xml" | tee $(results.integration-junit-url.path)        


### PR DESCRIPTION
https://github.com/crc-org/ci-definitions/issues/71
## Summary by Sourcery

Migrate s3-uploader to CI definitions by adding Tekton task configuration for uploading test results to AWS S3

New Features:
- Create a Tekton task for uploading test results to S3 with configurable parameters for bucket, path, and credentials

CI:
- Add Makefile target for s3-uploader Tekton task creation
- Introduce Tekton task template and configuration for S3 test result uploads

Chores:
- Add release-info file for s3-uploader version management