### PR TITLE
[crc-support]add support for install crc from oras

### DIFF
--- a/crc-support/oci/lib/windows/run.ps1
+++ b/crc-support/oci/lib/windows/run.ps1
@@ -81,6 +81,7 @@ $latestPath="$HOME\OpenshiftLocal\crc\latest"
 $install = If ($install -eq 'true') {$true} Else {$false}
 $download = If ($download -eq 'true') {$true} Else {$false}
 $freshEnv = If ($freshEnv -eq 'true') {$true} Else {$false}
+$delete = If ($delete -eq 'true') {$true} Else {$false}
 
 # FORCE FRESH
 if ($freshEnv) {

--- a/crc-support/tkn/task.yaml
+++ b/crc-support/tkn/task.yaml
@@ -21,6 +21,7 @@ spec:
     - name: host-secret
       secret:
         secretName: $(params.secret-host)
+    - name: orsa-asset      
   
   params:
     # OS parameter
@@ -50,6 +51,10 @@ spec:
     # Assets parameter
     - name: asset-base-url
       description: base url for the asset to be downloaded
+      default: ""
+    - name: asset-oras-address
+      description: the oras address of the asset
+      default: ""
     - name: asset-name
       description: name for the asset to be downloaded
     - name: asset-shasum-name
@@ -81,14 +86,29 @@ spec:
       description: Path on target host where the item has been dowloaded
     
   steps:
+  - name: oras-pull
+    image: ghcr.io/oras-project/oras:v1.2.3
+    when:
+      - input: "$(params.asset-oras-address)"
+        operator: notin
+        values: [""]
+    volumeMounts:
+      - name: orsa-asset
+        mountPath: /workspace
+    args: 
+      - pull
+      - $(params.asset-oras-address) 
   - name: preparer
     image: quay.io/crc-org/ci-crc-support:v2.0.0-dev-$(params.os) 
     imagePullPolicy: Always
     volumeMounts:
       - name: host-secret
         mountPath: /opt/host
+      - name: orsa-asset
+        mountPath: /opt/asset
     script: |
       #!/bin/bash
+      set -x
 
       if [ "$(params.debug)" = "true" ]; then
         set -xuo 
@@ -130,6 +150,22 @@ spec:
         tPath+="/crc/$(params.crc-version)"
       fi
 
+      download=$(params.download)
+      
+      if [[ -f /opt/asset/$(params.asset-name) ]]; then
+        echo "copy $(params.asset-name) to /opt/crc-support" 
+        cp /opt/asset/$(params.asset-name) /opt/crc-support
+        ls /opt/crc-support
+        download="false"
+        
+        tPath="/Users/${TARGET_HOST_USERNAME}/${TARGET_FOLDER}"
+        if [[ $(params.os) == 'linux' ]]; then
+          tPath="/home/${TARGET_HOST_USERNAME}/${TARGET_FOLDER}"
+        fi
+
+      else
+        echo "$(params.asset-name) not found"
+      fi
 
 
       cmd="${TARGET_FOLDER}/${runner} -targetPath $tPath "
@@ -137,7 +173,7 @@ spec:
       cmd+="-aName $(params.asset-name) "
       cmd+="-aSHAName $(params.asset-shasum-name) "
       cmd+="-freshEnv $(params.force-fresh) "
-      cmd+="-download $(params.download) "
+      cmd+="-download $download "
       cmd+="-install $(params.install) "
       cmd+="-delete $(params.delete) "
       
@@ -154,4 +190,5 @@ spec:
       limits:
         memory: "140Mi"
         cpu: "100m"
+    timeout: 60m
   

--- a/crc-support/tkn/tpl/task.tpl.yaml
+++ b/crc-support/tkn/tpl/task.tpl.yaml
@@ -21,6 +21,8 @@ spec:
     - name: host-secret
       secret:
         secretName: $(params.secret-host)
+    - name: orsa-asset      
+
   
   params:
     # OS parameter
@@ -50,6 +52,10 @@ spec:
     # Assets parameter
     - name: asset-base-url
       description: base url for the asset to be downloaded
+      default: ""
+    - name: asset-oras-address
+      description: the oras address of the asset
+      default: ""
     - name: asset-name
       description: name for the asset to be downloaded
     - name: asset-shasum-name
@@ -81,14 +87,29 @@ spec:
       description: Path on target host where the item has been dowloaded
     
   steps:
+  - name: oras-pull
+    image: ghcr.io/oras-project/oras:v1.2.3
+    when:
+      - input: "$(params.asset-oras-address)"
+        operator: notin
+        values: [""]
+    volumeMounts:
+      - name: orsa-asset
+        mountPath: /workspace
+    args: 
+      - pull
+      - $(params.asset-oras-address) 
   - name: preparer
     image: cimage:cversion-$(params.os) 
     imagePullPolicy: Always
     volumeMounts:
       - name: host-secret
         mountPath: /opt/host
+      - name: orsa-asset
+        mountPath: /opt/asset
     script: |
       #!/bin/bash
+      set -x
 
       if [ "$(params.debug)" = "true" ]; then
         set -xuo 
@@ -130,6 +151,22 @@ spec:
         tPath+="/crc/$(params.crc-version)"
       fi
 
+      download=$(params.download)
+      
+      if [[ -f /opt/asset/$(params.asset-name) ]]; then
+        echo "copy $(params.asset-name) to /opt/crc-support" 
+        cp /opt/asset/$(params.asset-name) /opt/crc-support
+        ls /opt/crc-support
+        download="false"
+        
+        tPath="/Users/${TARGET_HOST_USERNAME}/${TARGET_FOLDER}"
+        if [[ $(params.os) == 'linux' ]]; then
+          tPath="/home/${TARGET_HOST_USERNAME}/${TARGET_FOLDER}"
+        fi
+
+      else
+        echo "$(params.asset-name) not found"
+      fi
 
 
       cmd="${TARGET_FOLDER}/${runner} -targetPath $tPath "
@@ -137,7 +174,7 @@ spec:
       cmd+="-aName $(params.asset-name) "
       cmd+="-aSHAName $(params.asset-shasum-name) "
       cmd+="-freshEnv $(params.force-fresh) "
-      cmd+="-download $(params.download) "
+      cmd+="-download $download "
       cmd+="-install $(params.install) "
       cmd+="-delete $(params.delete) "
       
@@ -154,4 +191,5 @@ spec:
       limits:
         memory: "140Mi"
         cpu: "100m"
+    timeout: 60m
   


### PR DESCRIPTION
https://github.com/crc-org/ci-definitions/issues/81

## Summary by Sourcery

Add support for installing CRC (CodeReady Containers) from ORAS (OCI Registry As Storage)

New Features:
- Add ability to pull CRC assets directly from ORAS registry

Enhancements:
- Modify task template to support ORAS-based asset retrieval
- Update secret and volume configurations to accommodate ORAS asset pulling

Chores:
- Update task configuration to use ORAS pull mechanism
- Adjust parameter handling for asset download