### PR TITLE
[crc-builder]replace workspace with volume

### DIFF
--- a/crc-builder/tkn/tpl/crc-builder-arm64.tpl.yaml
+++ b/crc-builder/tkn/tpl/crc-builder-arm64.tpl.yaml
@@ -20,10 +20,21 @@ spec:
 
     As part of the steps included on the task an arm64 machine is provisioned to run the builder on it.
 
-  workspaces:
+  volumes:
     - name: pipelines-data
-      description: workspace to store outputs to connect within the target machine + state file for the infrastructure 
+      emptyDir: {}
     - name: s3-credentials
+      secret:
+        secretName: $(params.s3-credentials)      
+    - name: az-credentials
+      secret:
+        secretName: $(params.az-credentials)
+      
+
+  params:
+    # credentials
+    - name: s3-credentials
+      default: s3-aws-crcqe-asia
       description: |
         ocp secret holding the s3 credentials. Secret should be accessible to this task.
         ---
@@ -40,8 +51,8 @@ spec:
           bucket: ${bucket_value}  
           access-key: ${access_key}
           secret-key: ${secret_key}
-      mountPath: /opt/s3-credentials
     - name: az-credentials
+      default: aws-crcqe-bot
       description: |
         ocp secret holding the azure credentials. Secret should be accessible to this task.
 
@@ -52,9 +63,7 @@ spec:
         * client_secret
         * storage_account (optional if we use remote az storage)
         * storage_key (optional if we use remote az storage)
-      mountPath: /opt/credentials
-
-  params:
+    
     # SCM params
     - name: crc-scm
       default: https://github.com/code-ready/crc.git
@@ -87,6 +96,11 @@ spec:
   steps:
     - name: provisioner
       image: quay.io/redhat-developer/mapt:v0.7.4
+      volumeMounts:
+        - name: az-credentials
+          mountPath: /opt/credentials
+        - name: pipelines-data
+          mountPath: /opt/pipelines-data
       script: |
         #!/bin/sh
         set -x
@@ -104,7 +118,7 @@ spec:
         fi
         
         # Output folder
-        workspace_path=$(workspaces.pipelines-data.path)/fedora
+        workspace_path=/opt/pipelines-data/fedora
         mkdir -p ${workspace_path}
 
         # Run mapt
@@ -127,6 +141,11 @@ spec:
     - name: build
       # cimage and cversion values should be passed to the template
       image: quay.io/rhqp/support-tools:v0.0.4
+      volumeMounts:
+        - name: s3-credentials
+          mountPath: /opt/s3-credentials
+        - name: pipelines-data
+          mountPath: /opt/pipelines-data
       script: |
           #!/bin/sh
           set -x
@@ -157,9 +176,9 @@ spec:
           cmd+="-e DEBUG=true "
           cmd+="cimage:cversion-linux-arm64"
 
-          key=$(workspaces.pipelines-data.path)/fedora/id_rsa
-          username=$(cat $(workspaces.pipelines-data.path)/fedora/username)
-          host=$(cat $(workspaces.pipelines-data.path)/fedora/host)
+          key=/opt/pipelines-data/fedora/id_rsa
+          username=$(cat /opt/pipelines-data/fedora/username)
+          host=$(cat /opt/pipelines-data/fedora/host)
 
           # Exec
           # We need podman on the machine
@@ -189,6 +208,11 @@ spec:
       timeout: 900m
     - name: decommission
       image: quay.io/redhat-developer/mapt:v0.7.4
+      volumeMounts:
+        - name: az-credentials
+          mountPath: /opt/credentials
+        - name: pipelines-data
+          mountPath: /opt/pipelines-data
       onError: continue
       script: |
         #!/bin/sh
@@ -207,7 +231,7 @@ spec:
         fi
         
         # Output folder
-        workspace_path=$(workspaces.pipelines-data.path)/fedora
+        workspace_path=/opt/pipelines-data/fedora
         mkdir -p ${workspace_path}
 
         # Run mapt

--- a/crc-builder/tkn/tpl/crc-builder-installer.tpl.yaml
+++ b/crc-builder/tkn/tpl/crc-builder-installer.tpl.yaml
@@ -18,8 +18,17 @@ spec:
   description: >-
     This task will build openshift local installers 
 
-  workspaces:
+  volumes:
     - name: s3-credentials
+      secret:
+        secretName: $(params.s3-credentials)  
+    - name: host-info
+      secret:
+        secretName: $(params.host-info)
+
+  params:
+    - name: s3-credentials
+      default: s3-aws-crcqe-asia
       description: |
         ocp secret holding the s3 credentials. Secret should be accessible to this task.
         ---
@@ -36,7 +45,6 @@ spec:
           bucket: ${bucket_value}  
           access-key: ${access_key}
           secret-key: ${secret_key}
-      mountPath: /opt/s3-credentials
     - name: host-info
       description: |
         ocp secret holding the hsot info credentials. Secret should be accessible to this task.
@@ -50,16 +58,13 @@ spec:
         type: Opaque
         data:
           host: XXXX
-          user: XXXX
+          username: XXXX
           password: XXXX
-          key: XXXX
+          id_rsa: XXXX
           platform: XXXX
           os-version: XXXX
           arch: XXXX
           os: XXXX
-      mountPath: /opt/host/
-
-  params:
     # Manage task params
     - name: os
       description: valid values are macos and windows
@@ -91,7 +96,12 @@ spec:
   steps:
     - name: crc-executable-builder
       # cimage and cversion values should be passed to the template
-      image: cimage:cversion-$(params.os) 
+      image: cimage:cversion-$(params.os)
+      volumeMounts:
+        - name: s3-credentials
+          mountPath: /opt/s3-credentials
+        - name: host-info
+          mountPath: /opt/host/
       imagePullPolicy: Always
       script: |
           #!/bin/sh
@@ -100,8 +110,8 @@ spec:
           SECONDS=0
           DEBUG=$(params.debug)
           TARGET_HOST=$(cat /opt/host/host)
-          TARGET_HOST_USERNAME=$(cat /opt/host/user)
-          cp /opt/host/key id_rsa
+          TARGET_HOST_USERNAME=$(cat /opt/host/username)
+          cp /opt/host/id_rsa id_rsa
           chmod 600 id_rsa
           TARGET_HOST_KEY_PATH=id_rsa
           TARGET_FOLDER=crc-builder

--- a/crc-builder/tkn/tpl/crc-builder.tpl.yaml
+++ b/crc-builder/tkn/tpl/crc-builder.tpl.yaml
@@ -18,8 +18,14 @@ spec:
   description: >-
     This task will build openshift local binary for linux distributions 
 
-  workspaces:
+  volumes:
     - name: s3-credentials
+      secret:
+        secretName: $(params.s3-credentials)      
+
+  params:
+    - name: s3-credentials
+      default: s3-aws-crcqe-asia
       description: |
         ocp secret holding the s3 credentials. Secret should be accessible to this task.
         ---
@@ -36,9 +42,6 @@ spec:
           bucket: ${bucket_value}  
           access-key: ${access_key}
           secret-key: ${secret_key}
-      mountPath: /opt/s3-credentials
-
-  params:
     # SCM params
     - name: crc-scm
       default: https://github.com/code-ready/crc.git
@@ -64,6 +67,9 @@ spec:
       # cimage and cversion values should be passed to the template
       image: cimage:cversion-linux
       imagePullPolicy: Always
+      volumeMounts:
+        - name: s3-credentials
+          mountPath: /opt/s3-credentials
       script: |
           #!/bin/sh
 


### PR DESCRIPTION
fix https://github.com/crc-org/ci-definitions/issues/72

## Summary by Sourcery

Replace Tekton workspaces with Kubernetes volumes for managing pipeline data and credentials in crc-builder templates

Enhancements:
- Replace Tekton workspace bindings with volume definitions in ARM64, installer, and binary builder tasks
- Add secret-based volumes and corresponding params for S3, Azure, and host-info credentials
- Update volumeMounts in task steps and adjust path references to static mount points under /opt