### PR TITLE
[crc-builder]fix github workflow failure

### DIFF
--- a/.github/workflows/crc-builder-builder.yaml
+++ b/.github/workflows/crc-builder-builder.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: Prepare runner
         shell: bash
         run: |
+          sudo apt-get update
           sudo apt-get install -y qemu-user-static
 
       - name: Build image for PR


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Run 'sudo apt-get update' before installing qemu-user-static in crc-builder workflow to ensure package availability