### PR TITLE
[crc-support] support install crc from asset inside image

### DIFF
--- a/crc-support/oci/lib/darwin/lib.sh
+++ b/crc-support/oci/lib/darwin/lib.sh
@@ -30,7 +30,11 @@ check_download() {
 
 # $1 file name for crc installer
 installCRC() {
-    sudo installer -pkg ${1} -target /
+    if [[ ${1} == *.pkg ]]; then
+        sudo installer -pkg ${1} -target /
+    else
+        sudo cp ${1} /usr/local/bin/
+    fi
 }
 
 

--- a/crc-support/tkn/task.yaml
+++ b/crc-support/tkn/task.yaml
@@ -21,7 +21,7 @@ spec:
     - name: host-secret
       secret:
         secretName: $(params.secret-host)
-    - name: orsa-asset      
+    - name: v-image-asset      
   
   params:
     # OS parameter
@@ -51,10 +51,16 @@ spec:
     # Assets parameter
     - name: asset-base-url
       description: base url for the asset to be downloaded
-      default: ""
+      default: "''"
     - name: asset-oras-address
       description: the oras address of the asset
       default: ""
+    - name: asset-image-address
+      default: ""
+      description: The image that contains the asset
+    - name: asset-image-path
+      default: "/opt"
+      description: The path within the container of the assest
     - name: asset-name
       description: name for the asset to be downloaded
     - name: asset-shasum-name
@@ -93,18 +99,32 @@ spec:
         operator: notin
         values: [""]
     volumeMounts:
-      - name: orsa-asset
+      - name: v-image-asset
         mountPath: /workspace
     args: 
       - pull
       - $(params.asset-oras-address) 
+  - name: get-image-content
+    image: $(params.asset-image-address)
+    when:
+      - input: "$(params.asset-image-address)"
+        operator: notin
+        values: [""]
+    volumeMounts:
+      - name: v-image-asset
+        mountPath: /opt/asset
+    script: |
+      #!/bin/bash
+      set -x
+      cp $(params.asset-image-path)/$(params.asset-name) /opt/asset/
+
   - name: preparer
     image: quay.io/crc-org/ci-crc-support:v2.0.0-dev-$(params.os) 
     imagePullPolicy: Always
     volumeMounts:
       - name: host-secret
         mountPath: /opt/host
-      - name: orsa-asset
+      - name: v-image-asset
         mountPath: /opt/asset
     script: |
       #!/bin/bash

--- a/crc-support/tkn/tpl/task.tpl.yaml
+++ b/crc-support/tkn/tpl/task.tpl.yaml
@@ -21,8 +21,7 @@ spec:
     - name: host-secret
       secret:
         secretName: $(params.secret-host)
-    - name: orsa-asset      
-
+    - name: v-image-asset      
   
   params:
     # OS parameter
@@ -52,10 +51,16 @@ spec:
     # Assets parameter
     - name: asset-base-url
       description: base url for the asset to be downloaded
-      default: ""
+      default: "''"
     - name: asset-oras-address
       description: the oras address of the asset
       default: ""
+    - name: asset-image-address
+      default: ""
+      description: The image that contains the asset
+    - name: asset-image-path
+      default: "/opt"
+      description: The path within the container of the assest
     - name: asset-name
       description: name for the asset to be downloaded
     - name: asset-shasum-name
@@ -94,18 +99,32 @@ spec:
         operator: notin
         values: [""]
     volumeMounts:
-      - name: orsa-asset
+      - name: v-image-asset
         mountPath: /workspace
     args: 
       - pull
       - $(params.asset-oras-address) 
+  - name: get-image-content
+    image: $(params.asset-image-address)
+    when:
+      - input: "$(params.asset-image-address)"
+        operator: notin
+        values: [""]
+    volumeMounts:
+      - name: v-image-asset
+        mountPath: /opt/asset
+    script: |
+      #!/bin/bash
+      set -x
+      cp $(params.asset-image-path)/$(params.asset-name) /opt/asset/
+
   - name: preparer
     image: cimage:cversion-$(params.os) 
     imagePullPolicy: Always
     volumeMounts:
       - name: host-secret
         mountPath: /opt/host
-      - name: orsa-asset
+      - name: v-image-asset
         mountPath: /opt/asset
     script: |
       #!/bin/bash


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pulling assets from a container image by specifying new parameters for the image address and asset path.
  * Introduced a new step to extract asset files from a specified container image when provided.

* **Improvements**
  * Renamed asset volume for clarity and consistency across steps.
  * Enhanced installation logic to support both package installers and binary files on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->