### PR TITLE
S3 uploader and reportportal support uploading test result form oras

### DIFF
--- a/reportportal/tkn/import-oras.yaml
+++ b/reportportal/tkn/import-oras.yaml
@@ -1,0 +1,172 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: reportportal-import
+  labels:
+    app.kubernetes.io/version: "v1.0.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.24.x"
+    tekton.dev/categories: data
+    tekton.dev/tags: "data, results"
+    tekton.dev/displayName: "report portal import"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: |
+    Task to import junit results into report portal
+  
+  params:
+  - name: secret-reportportal
+    description: |
+      ocp secret holding the report portal credentials. Secret should be accessible to this task.
+
+      ---
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: XXX
+      type: Opaque
+      data:
+        token: XXXX
+        url: XXXX
+        project: XXXX
+    default: reportportal-crc
+  - name: oras-address
+  - name: results-id
+    description: Identifier for the results. Typically will include metadata about the environment or the product
+  - name: results-wsstorage-path
+    description: path within the storage workspace for the results file to be uploaded
+  - name: launch-attributes
+    description: |
+      The attributes for the launch, will show as tag in reportportal. 
+      The value format is 
+      {"attributes": [{"key":"crc-version","value":"20240926"}, {"key":"bundle-version","value":"4.17.0-rc.5"}]}
+  - name: launch-description
+    description: The description for the launch.
+    default: nightly-run
+  # Control
+  - name: debug
+    description: debug the task cmds
+    default: 'false' 
+  - name: upload-log
+    default: 'false'
+    description: |
+      whether upload the current pipelinerun logs. 
+      If true, the task will gather current pipeline-run logs to xml, then upload to reportportal.
+      So recommend put this task in Final block of pipeline. 
+  - name: pipelinerunName
+    default: $(context.pipelineRun.name)
+    description: the pipelinerun name which log be uploaded to reportportal 
+
+  steps:
+  - name: oras-pull
+    image: ghcr.io/oras-project/oras:v1.2.3
+    volumeMounts:
+      - name: oras-content
+        mountPath: /workspace
+    script: |
+      #!/bin/sh
+      oras pull $(params.oras-address)
+      tar -xvf test-result.tar
+      ls qe-results
+  - name: import
+    image: quay.io/crc-org/reportportal:v1.0.0 #v0.0.5
+    imagePullPolicy: Always
+    volumeMounts:
+      - name: reportportal-credentials
+        mountPath: /opt/reportportal-credentials
+      - name: oras-content
+        mountPath: /opt/results
+    script: |
+      #!/bin/sh
+      set -e
+      set -x
+
+      # If debug add verbosity
+      if [[ $(params.debug) == "true" ]]; then
+        set -exuo pipefail
+      fi
+
+      if [[ $(params.upload-log) == 'true' ]]; then
+        echo $(params.pipelinerunName)
+        tkn pipelinerun list | grep $(params.pipelinerunName)
+        if [[ $? == 0 ]]; then
+          tkn pipelinerun logs $(params.pipelinerunName) > pipelinerun.log
+          logPath=pipelinerun.log
+          xmlPath=pipelineLog.xml
+          python3 /opt/trans-log-xml.py $logPath $xmlPath
+          ls -lh
+        else 
+          echo "no pipelinerun $(params.pipelinerunName) found"
+        fi
+      fi
+
+      failFlag='false'
+      # Prepare results
+      if find "/opt/results/$(params.results-wsstorage-path)" -maxdepth 1 -name "*.xml" -print -quit | grep -q .; then
+        cp /opt/results/$(params.results-wsstorage-path)/*.xml .
+      else
+        failFlag='true'
+      fi
+      # remove the xml file if its size is 0 byte
+      # find "/opt/results/$(params.results-wsstorage-path)" -type f -name "*.xml" -size 0 -exec rm {} \;
+
+
+      # Compress
+      if [[ $failFlag == 'true' ]]; then
+        fileName="fail-pipelinerun"
+      else
+        fileName=$(params.results-id)
+      fi
+
+      zip "$fileName.zip" *.xml
+      # Import
+      url=$(cat /opt/reportportal-credentials/url)
+      token=$(cat /opt/reportportal-credentials/token)
+      project=$(cat /opt/reportportal-credentials/project)
+      description=""
+      if [[ $failFlag != 'true' ]]; then
+        description="$(params.launch-description)"
+      else
+        description="$(params.results-id)"
+      fi
+      upload=`curl -k -X POST "${url}/api/v1/${project}/launch/import" \
+          -H "accept: */*" -H "Content-Type: multipart/form-data" \
+          -H "Authorization: bearer ${token}" \
+          -F "file=@$fileName.zip" \
+          -F "launchImportRq={
+            \"attributes\": [
+              {
+                \"key\": \"skippedIsNotIssue\",
+                \"system\": true,
+                \"value\": \"true\"
+              }
+            ],
+            \"description\": \"${description}\"
+          };type=application/json"`
+      uuid=`echo ${upload#*= } | cut -d " " -f1`
+      getid=`curl -k -X GET "${url}/api/v1/${project}/launch/uuid/${uuid}" \
+          -H "accept: */*" -H  "Authorization: bearer ${token}"`
+      launchId=`echo $getid | jq .id`
+      if [[ $failFlag != 'true' ]]; then
+        curl -k -X PUT "${url}/api/v1/${project}/launch/${launchId}/update" \
+            -H "accept: */*" -H "Content-Type: application/json" \
+            -H "Authorization: bearer ${token}" \
+            -d '$(params.launch-attributes)'
+      fi
+
+    resources:      
+      requests:
+        memory: "100Mi"
+        cpu: "50m"
+      limits:
+        memory: "200Mi"
+        cpu: "100m"
+
+  volumes:
+    - name: oras-content
+    - name: reportportal-credentials
+      secret:
+        secretName: $(params.secret-reportportal)
+    
+    

--- a/s3-uploader/tkn/task-oras.yaml
+++ b/s3-uploader/tkn/task-oras.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: s3-uploader-oras
+  labels:
+    app.kubernetes.io/version: "v1.0.0"
+    redhat.com/product: openshift-local
+    dev.lifecycle.io/phase: testing
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.44.x"
+    tekton.dev/categories: "openshift-local"
+    tekton.dev/tags: "openshift-local, testing"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This task will upload test results to aws s3
+
+  volumes:
+    - name: aws-credentials
+      secret:
+        secretName: $(params.aws-credentials)
+    - name: oras-content
+  
+  params:
+    - name: aws-credentials
+      description: |
+        ocp secret holding the aws credentials. Secret should be accessible to this task.
+        ---
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-${name}
+          labels:
+            app.kubernetes.io/component: ${name}
+            app.kubernetes.io/part-of: qe-platform
+        type: Opaque
+        data:
+          access-key: ${access_key}
+          secret-key: ${secret_key}
+          region: ${region}
+      default: aws-crcqe-bot
+    - name: oras-address
+    - name: qe-workspace-subpath
+    - name: s3-bucket
+    - name: s3-path
+      description: Path inside the bucket to upload the assets i.e folder...nightly/crc/$date/linux-arm64
+
+  results:
+    - name: e2e-junit-url
+    - name: integration-junit-url
+    
+  steps:
+    - name: oras-pull
+      image: ghcr.io/oras-project/oras:v1.2.3
+      volumeMounts:
+        - name: oras-content
+          mountPath: /workspace
+      script: |
+        #!/bin/sh
+        oras pull $(params.oras-address)
+        tar -xvf test-result.tar
+        ls qe-results
+    - name: uploader
+      image: quay.io/crc-org/s3-uploader:v1.0.0
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: aws-credentials
+          mountPath: /opt/aws-credentials
+        - name: oras-content
+          mountPath: /opt/results
+      script: |
+        #!/bin/sh
+        mkdir -p /home/1001/.aws
+        cat <<EOF > /home/1001/.aws/credentials
+        [default]
+        aws_access_key_id     = $(cat /opt/aws-credentials/access-key)
+        aws_secret_access_key = $(cat /opt/aws-credentials/secret-key)
+        EOF
+        cat <<EOF > /home/1001/.aws/config
+        [default]
+        region = $(cat /opt/aws-credentials/region)
+        EOF
+
+        region=$(cat /opt/aws-credentials/region)
+        echo $region
+
+        aws s3 cp --recursive /opt/results/$(params.qe-workspace-subpath)/ s3://$(params.s3-bucket)/$(params.s3-path)
+        
+        echo -n "https://$(params.s3-bucket).s3.${region}.amazonaws.com/$(params.s3-path)/e2e-junit.xml" | tee $(results.e2e-junit-url.path)
+        echo -n "https://$(params.s3-bucket).s3.${region}.amazonaws.com/$(params.s3-path)/integration-junit.xml" | tee $(results.integration-junit-url.path)        


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Tekton Task to automate importing JUnit test results into ReportPortal with support for log uploads and custom launch attributes.
  * Added a Tekton Task to upload test results to AWS S3, generating public URLs for e2e and integration JUnit XML reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->