### PR TITLE
[pipline]bump mapt version to v0.9.0 

### DIFF
--- a/pipelines/crc-qe-latest-arm64.yaml
+++ b/pipelines/crc-qe-latest-arm64.yaml
@@ -168,7 +168,7 @@ spec:
           - name: url
             value: https://github.com/redhat-developer/mapt.git
           - name: revision
-            value: v0.9.5
+            value: v0.9.6
           - name: pathInRepo
             value: tkn/infra-aws-fedora.yaml
       params:
@@ -396,7 +396,7 @@ spec:
           - name: url
             value: https://github.com/redhat-developer/mapt.git
           - name: revision
-            value: v0.9.5
+            value: v0.9.6
           - name: pathInRepo
             value: tkn/infra-aws-fedora.yaml
       params:

--- a/pipelines/crc-qe-virtual-fedora.yaml
+++ b/pipelines/crc-qe-virtual-fedora.yaml
@@ -53,7 +53,7 @@ spec:
           - name: url
             value: https://github.com/redhat-developer/mapt
           - name: revision
-            value: v0.8.0
+            value: v0.9.6
           - name: pathInRepo
             value: tkn/infra-aws-fedora.yaml
       params:
@@ -183,7 +183,7 @@ spec:
           - name: url
             value: https://github.com/redhat-developer/mapt
           - name: revision
-            value: v0.8.0
+            value: v0.9.6
           - name: pathInRepo
             value: tkn/infra-aws-fedora.yaml
       params:


### PR DESCRIPTION
https://github.com/redhat-developer/mapt/issues/563 leads to a provisioned machine not supporting virtualization 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the external "mapt" tool used by provisioning and decommissioning steps in CI pipelines to v0.9.6.
  * Applied the version update across both ARM64 and virtual Fedora pipeline workflows to ensure consistent tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->