### PR TITLE
[pipeline]crc-qe-latest-arm64 fix build binary failure

### DIFF
--- a/pipelines/crc-qe-latest-arm64.yaml
+++ b/pipelines/crc-qe-latest-arm64.yaml
@@ -146,7 +146,7 @@ spec:
           - name: url
             value: https://github.com/crc-org/ci-definitions
           - name: revision
-            value: crc-builder-v1.1.0
+            value: crc-builder-v1.1.1
           - name: pathInRepo
             value: crc-builder/tkn/crc-builder-arm64.yaml
       params:


### PR DESCRIPTION
fix https://github.com/crc-org/ci-definitions/issues/99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ARM64 build pipeline to use the latest builder, improving build consistency and compatibility on Apple Silicon and other ARM64 environments.
  * No user-facing features changed; installations and updates on ARM64 are expected to be more stable.
  * Ensures continued support for recent toolchains and dependencies during packaging for ARM64 builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->