### PR TITLE
[opensearch] fix failure when no txt file

### DIFF
--- a/open-search/oci/opensearch-upload.py
+++ b/open-search/oci/opensearch-upload.py
@@ -3,6 +3,7 @@ import argparse
 import requests
 from datetime import datetime, timezone
 import os
+import sys
 
 parser = argparse.ArgumentParser(description="upload performace test data to opensearch")
 parser.add_argument("--index", help="opensearch index name", default="crc-test")
@@ -17,7 +18,8 @@ if not folder_path or not os.path.isdir(folder_path):
     raise SystemExit(f"Invalid --path: {folder_path!r}")
 txt_files = [f for f in os.listdir(folder_path) if f.endswith(".txt")]
 if len(txt_files) == 0:
-    raise SystemExit(f"No txt file in: {folder_path!r}")
+    print("No txt file in {}".format(folder_path))
+    sys.exit(0)
 
 all={}
 for file_name in txt_files:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When no .txt files are found in the selected folder, the upload tool now exits gracefully with a clear informational message and a success exit code, instead of raising an error.
  * Improves CLI behavior in automated environments by preventing false failures and reducing noisy error logs, while leaving all other functionalities unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->