### PR TITLE
[pipeline] mapt version set up v0.9.7

### DIFF
--- a/pipelines/crc-qe-latest-arm64.yaml
+++ b/pipelines/crc-qe-latest-arm64.yaml
@@ -168,7 +168,7 @@ spec:
           - name: url
             value: https://github.com/redhat-developer/mapt.git
           - name: revision
-            value: main
+            value: v0.9.7
           - name: pathInRepo
             value: tkn/infra-aws-fedora.yaml
       params:
@@ -422,7 +422,7 @@ spec:
           - name: url
             value: https://github.com/redhat-developer/mapt.git
           - name: revision
-            value: main
+            value: v0.9.7
           - name: pathInRepo
             value: tkn/infra-aws-fedora.yaml
       params:

--- a/pipelines/crc-qe-virtual-fedora.yaml
+++ b/pipelines/crc-qe-virtual-fedora.yaml
@@ -53,7 +53,7 @@ spec:
           - name: url
             value: https://github.com/redhat-developer/mapt
           - name: revision
-            value: main
+            value: v0.9.7
           - name: pathInRepo
             value: tkn/infra-aws-fedora.yaml
       params:
@@ -185,7 +185,7 @@ spec:
           - name: url
             value: https://github.com/redhat-developer/mapt
           - name: revision
-            value: main
+            value: v0.9.7
           - name: pathInRepo
             value: tkn/infra-aws-fedora.yaml
       params:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Pinned external task revisions to v0.9.7 in CRC QE pipelines (ARM64 Latest and Virtual Fedora) for both provisioning and decommission stages.
  * Ensures consistent, reproducible runs and reduces drift from upstream changes without altering pipeline flow.
  * Aligns both pipelines on the same vetted release across environments, improving reliability and traceability.
  * No user-facing behavior changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->