### PR TITLE
[reportportal]add parameter for remove folder in pvc

### DIFF
--- a/reportportal/tkn/import.yaml
+++ b/reportportal/tkn/import.yaml
@@ -59,6 +59,9 @@ spec:
   - name: pipelinerunName
     default: $(context.pipelineRun.name)
     description: the pipelinerun name which log be uploaded to reportportal 
+  - name: remove-PVC-folder
+    default: 'true'
+    description: Remove the folder in PVC after import to reportportal
 
   steps:
   - name: import
@@ -149,11 +152,13 @@ spec:
       fi
 
       # delete the folder in pvc
-      path=$(params.results-wsstorage-path)
-      IFS='/' read -ra folder <<< "$path"
-      if [ -d "/opt/storage/$folder" ]; then
-        ls /opt/storage/$folder
-        rm -r /opt/storage/$folder
+      if [[ $(params.remove-PVC-folder) == "true" ]]; then
+        path=$(params.results-wsstorage-path)
+        IFS='/' read -ra folder <<< "$path"
+        if [ -d "/opt/storage/$folder" ]; then
+          ls /opt/storage/$folder
+          rm -r /opt/storage/$folder
+        fi
       fi
 
     resources:      


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option for the import process allowing users to choose whether to preserve or remove PVC folders after importing to ReportPortal. Previously, folders were automatically deleted after import.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->