### PR TITLE
[reportportal]: mark rp launches as failed when the pipeline run fails

### DIFF
--- a/reportportal/oci/trans-log-xml.py
+++ b/reportportal/oci/trans-log-xml.py
@@ -3,14 +3,18 @@ import xml.etree.ElementTree as ET
 from xml.dom import minidom
 import sys
 
-def log_to_xml_with_steps(log_file, xml_file):
+def log_to_xml_with_steps(log_file, xml_file, fail_flag):
     # Create the root element for XML
     root = ET.Element("testsuites", name="pipeline-logs")
     suit_element = ET.SubElement(root, "testsuite", name='piplinerun')
     case_element = ET.SubElement(suit_element, "testcase",name='logs')
     root.set("tests", "1")
-    root.set("failures", "0")
-    root.set("status", "passed")
+    if fail_flag:
+        root.set("failures", "1")
+        root.set("status", "failed")
+    else:
+        root.set("failures", "0")
+        root.set("status", "passed")
 
     step_element = None
     task_element = None
@@ -56,10 +60,11 @@ def log_to_xml_with_steps(log_file, xml_file):
     print(f"Log file with steps converted to XML report: {xml_file}")
 
 
-if len(sys.argv) < 2:
-    print("Usage: python example.py <param1> <param2>")
+if len(sys.argv) < 4:
+    print("Usage: python example.py <param1> <param2> <param3>")
     sys.exit(1)
 
 log_file = sys.argv[1]  # First parameter
 xml_file = sys.argv[2]
-log_to_xml_with_steps(log_file, xml_file)
+fail_flag = sys.argv[3].lower() == "true"
+log_to_xml_with_steps(log_file, xml_file, fail_flag)

--- a/reportportal/tkn/import.yaml
+++ b/reportportal/tkn/import.yaml
@@ -81,20 +81,6 @@ spec:
         set -exuo pipefail
       fi
 
-      if [[ $(params.upload-log) == 'true' ]]; then
-        echo $(params.pipelinerunName)
-        tkn pipelinerun list | grep $(params.pipelinerunName)
-        if [[ $? == 0 ]]; then
-          tkn pipelinerun logs $(params.pipelinerunName) > pipelinerun.log
-          logPath=pipelinerun.log
-          xmlPath=pipelineLog.xml
-          python3 /opt/trans-log-xml.py $logPath $xmlPath
-          ls -lh
-        else 
-          echo "no pipelinerun $(params.pipelinerunName) found"
-        fi
-      fi
-
       failFlag='false'
       
       # remove the xml file if its size is 0 byte
@@ -107,6 +93,19 @@ spec:
         failFlag='true'
       fi
 
+      if [[ $(params.upload-log) == 'true' ]]; then
+        echo $(params.pipelinerunName)
+        tkn pipelinerun list | grep $(params.pipelinerunName)
+        if [[ $? == 0 ]]; then
+          tkn pipelinerun logs $(params.pipelinerunName) > pipelinerun.log
+          logPath=pipelinerun.log
+          xmlPath=pipelineLog.xml
+          python3 /opt/trans-log-xml.py $logPath $xmlPath $failFlag
+          ls -lh
+        else 
+          echo "no pipelinerun $(params.pipelinerunName) found"
+        fi
+      fi
 
       # Compress
       if [[ $failFlag == 'true' ]]; then
@@ -177,5 +176,3 @@ spec:
     - name: reportportal-credentials
       secret:
         secretName: $(params.secret-reportportal)
-    
-    


### PR DESCRIPTION
issue: https://github.com/containers/podman-desktop-internal/issues/690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now accepts an additional parameter to explicitly mark a run as failed; generated reports reflect passed/failed status accordingly.

* **Improvements**
  * Processing now determines failure status before upload, and the log-to-report flow is reordered so uploads use the determined status for more accurate reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->