### PR TITLE
[crc-support] Add fallback url for download

### DIFF
--- a/crc-support/oci/lib/unix/run.sh
+++ b/crc-support/oci/lib/unix/run.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "${SCRIPT_DIR}/lib.sh"
 
 # Parameters
-aBaseURL=''
+aBaseURLs=''
 aName=''
 aSHAName='sha256sum.txt'
 targetPath=''
@@ -17,8 +17,8 @@ delete='false'
 while [[ $# -gt 0 ]]; do
     key="$1"
     case $key in
-        -aBaseURL)
-        aBaseURL="$2"
+        -aBaseURLs)
+        aBaseURLs="$2"
         shift 
         shift 
         ;;
@@ -79,6 +79,17 @@ download () {
     done
 }
 
+download_check () {
+    local name="$1"
+    local base="$2"
+    local sha="$3"
+
+    rm -f $name
+    dURL="$base/$name"
+    download $dURL
+    check_download $name $sha
+}
+
 ##############
 #### MAIN ####
 ##############
@@ -97,24 +108,37 @@ pushd $targetPath
 
 # DOWNLOAD
 if [[ $download == "true" ]]; then
-    echo "downlading $aName"
-    
-    # Download sha256sum
-    curl --insecure -LO "$aBaseURL/$aSHAName"
-    # Check if require download
+    echo "downloading $aName"
+
+    oldIFS="$IFS"
+    IFS=','
+
+    for url in $aBaseURLs; do
+        curl --insecure -LO "$url/$aSHAName" && break
+        echo "Failed to get shasum from $url, trying next..."
+    done
+
+    IFS="$oldIFS"
     required_download $aName $aSHAName
     if [[ ${?} -ne 0 ]]; then
-        # Required to download
-        rm -f $aName
-        dURL="$aBaseURL/$aName"
-        download $dURL
-        check_download $aName $aSHAName
-        if [[ ${?} -ne 0 ]]; then 
-            echo "Error with downloading $aName"
+        downloaded=false
+        IFS=','
+        for url in $aBaseURLs; do
+            IFS="$oldIFS"
+            download_check "$aName" "$url" "$aSHAName"
+            if [[ ${?} -eq 0 ]]; then
+                downloaded=true
+                break
+            fi
+            echo "Error downloading $aName from $url, trying next..."
+            IFS=','
+        done
+        IFS="$oldIFS"
+        if [[ "$downloaded" != "true" ]]; then
+            echo "Error downloading $aName from all URLs"
             exit 1
         fi
     fi
-
 fi
 
 # INSTALLATION

--- a/crc-support/oci/lib/windows/run.ps1
+++ b/crc-support/oci/lib/windows/run.ps1
@@ -1,6 +1,6 @@
 param(
-    [Parameter(HelpMessage='download base url')]
-    $aBaseURL,
+    [Parameter(HelpMessage='download base urls, comma separated for fallback')]
+    $aBaseURLs,
     [Parameter(HelpMessage='asset name to be downloaded')]
     $aName,
     [Parameter(HelpMessage='shasumFile file name Default value: sha256sum.txt')]
@@ -55,7 +55,16 @@ function Check-Download() {
     $hashValue=Get-FileHash $aName | Select-Object -ExpandProperty Hash
     $hashMatch=Select-String $aSHAName -Pattern $hashValue -Quiet
     return $hashMatch
-} 
+}
+
+function Download-Check ($baseURL) {
+    if (Test-Path $aName) {
+        Remove-Item $aName
+    }
+    $distributableURL="$baseURL/$aName"
+    Download $distributableURL
+    return Check-Download
+}
 
 function Pause-Until-Other-Installations-Finish() {
     do {
@@ -93,19 +102,30 @@ pushd $targetPath
 
 # DOWNLOAD
 if ($download) {
-    # Download sha256sum
-    curl.exe --insecure -LO "$aBaseURL/$aSHAName"
+    Write-Host "downloading $aName"
+    $urls = $aBaseURLs -split ','
+
+    # Download sha256sum from first available URL
+    foreach ($url in $urls) {
+        curl.exe --insecure -LO "$url/$aSHAName"
+        if ($?) { break }
+        Write-Host "Failed to get shasum from $url, trying next..."
+    }
+
     # Check if require download
     if (Require-Download $targetPath) {
-        if (Test-Path $aName) {
-            Remove-Item $aName
+        $downloaded = $false
+        foreach ($url in $urls) {
+            $check = Download-Check $url
+            if ($check) {
+                $downloaded = $true
+                break
+            }
+            Write-Host "Error downloading $aName from $url, trying next..."
         }
-        $distributableURL="$aBaseURL/$aName"
-        Download $distributableURL
-        $check=Check-Download
-        if (!$check) {
+        if (!$downloaded) {
             popd
-            Write-Host "Error with downloaded binary"
+            Write-Host "Error downloading $aName from all URLs"
             Exit
         }
     }

--- a/crc-support/release-info
+++ b/crc-support/release-info
@@ -1,2 +1,2 @@
 quay.io/crc-org/ci-crc-support
-2.0.0-dev
+2.0.0-dbg

--- a/crc-support/tkn/task.yaml
+++ b/crc-support/tkn/task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: crc-support
   labels:
-    app.kubernetes.io/version: "v2.0.0-dev"
+    app.kubernetes.io/version: "v2.0.0-dbg"
     redhat.com/product: openshift-local
     dev.lifecycle.io/phase: testing
   annotations:
@@ -119,7 +119,7 @@ spec:
       cp $(params.asset-image-path)/$(params.asset-name) /opt/asset/
 
   - name: preparer
-    image: quay.io/crc-org/ci-crc-support:v2.0.0-dev-$(params.os) 
+    image: quay.io/crc-org/ci-crc-support:v2.0.0-dbg-$(params.os) 
     imagePullPolicy: Always
     volumeMounts:
       - name: host-secret

--- a/crc-support/tkn/task.yaml
+++ b/crc-support/tkn/task.yaml
@@ -49,8 +49,8 @@ spec:
           arch: XXXX
           os: XXXX
     # Assets parameter
-    - name: asset-base-url
-      description: base url for the asset to be downloaded
+    - name: asset-base-urls
+      description: comma-separated list of base urls to try in order for downloading the asset
       default: "''"
     - name: asset-oras-address
       description: the oras address of the asset
@@ -189,7 +189,7 @@ spec:
 
 
       cmd="${TARGET_FOLDER}/${runner} -targetPath $tPath "
-      cmd+="-aBaseURL $(params.asset-base-url) "
+      cmd+="-aBaseURLs '$(params.asset-base-urls)' "
       cmd+="-aName $(params.asset-name) "
       cmd+="-aSHAName $(params.asset-shasum-name) "
       cmd+="-freshEnv $(params.force-fresh) "

--- a/crc-support/tkn/tpl/task.tpl.yaml
+++ b/crc-support/tkn/tpl/task.tpl.yaml
@@ -49,8 +49,8 @@ spec:
           arch: XXXX
           os: XXXX
     # Assets parameter
-    - name: asset-base-url
-      description: base url for the asset to be downloaded
+    - name: asset-base-urls
+      description: comma-separated list of base urls to try in order for downloading the asset
       default: "''"
     - name: asset-oras-address
       description: the oras address of the asset
@@ -189,7 +189,7 @@ spec:
 
 
       cmd="${TARGET_FOLDER}/${runner} -targetPath $tPath "
-      cmd+="-aBaseURL $(params.asset-base-url) "
+      cmd+="-aBaseURLs '$(params.asset-base-urls)' "
       cmd+="-aName $(params.asset-name) "
       cmd+="-aSHAName $(params.asset-shasum-name) "
       cmd+="-freshEnv $(params.force-fresh) "

--- a/pipelines/crc-qe-latest-arm64.yaml
+++ b/pipelines/crc-qe-latest-arm64.yaml
@@ -29,8 +29,8 @@ spec:
     - name: az-credentials
       default: az-crcqe-bot
     # Existing components
-    - name: bundle-base-url
-      description: base url to download bundle and shasumsfile
+    - name: bundle-base-urls
+      description: comma-separated list of base urls to try in order for downloading bundle
     - name: bundle-name
       description: bundle name
     - name: bundle-shasumfile
@@ -262,8 +262,8 @@ spec:
       params:
         - name: secret-host
           value: $(tasks.provision-tester.results.host-access-secret)
-        - name: asset-base-url
-          value: $(params.bundle-base-url) 
+        - name: asset-base-urls
+          value: $(params.bundle-base-urls)
         - name: asset-name
           value: $(params.bundle-name)
         - name: asset-shasum-name

--- a/pipelines/crc-qe-latest.yaml
+++ b/pipelines/crc-qe-latest.yaml
@@ -65,8 +65,8 @@ spec:
     - name: s3-credentials
       default: s3-aws-crcqe-asia
     # Existing components
-    - name: bundle-base-url
-      description: base url to download bundle and shasumsfile
+    - name: bundle-base-urls
+      description: comma-separated list of base urls to try in order for downloading bundle
     - name: bundle-name
       description: bundle name
     - name: bundle-shasumfile
@@ -206,8 +206,8 @@ spec:
           value: $(params.secret-tester)
         - name: os
           value: $(tasks.init.results.os)
-        - name: asset-base-url
-          value: $(params.bundle-base-url)
+        - name: asset-base-urls
+          value: $(params.bundle-base-urls)
         - name: asset-name
           value: $(params.bundle-name)
         - name: asset-shasum-name
@@ -378,7 +378,7 @@ spec:
           value: $(params.secret-tester)
         - name: os
           value: $(tasks.init.results.os)
-        - name: asset-base-url
+        - name: asset-base-urls
           value: $(tasks.sync-build.results.asset-url)
         - name: asset-name
           value: $(tasks.sync-build.results.asset-name)


### PR DESCRIPTION
Allow to check alternative download url if provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow specifying multiple asset and bundle base URLs (comma-separated) so downloads can fall back to alternate sources.

* **Bug Fixes**
  * Improved download resilience: checksum/sha verification is preserved while trying sources in order and removing stale local copies between attempts.

* **Chores**
  * Updated the Tekton preparer image tag and release info to a debug (`2.0.0-dbg`) build label.
  * Renamed parameters from `*-base-url` to `*-base-urls` in tasks and pipelines to match the comma-separated format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->