### PR TITLE
opensearch remove volume description

### DIFF
--- a/open-search/upload.yaml
+++ b/open-search/upload.yaml
@@ -88,7 +88,6 @@ spec:
 
   volumes:
     - name: storage
-      description: storage volume where to find the results to be imported
       persistentVolumeClaim:
         claimName: $(params.pvc)
     - name: opensearch


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal configuration by removing an unused field from the storage volume definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->