### PR TITLE
[reportportal]update due to API change

### DIFF
--- a/reportportal/tkn/import.yaml
+++ b/reportportal/tkn/import.yaml
@@ -134,7 +134,7 @@ spec:
       else
         description="$(params.results-id)"
       fi
-      upload=`curl -k -X POST "${url}/api/v1/${project}/launch/import" \
+      upload=`curl -k -X POST "${url}/api/v1/plugin/${project}/junit/import" \
           -H "accept: */*" -H "Content-Type: multipart/form-data" \
           -H "Authorization: bearer ${token}" \
           -F "file=@$fileName.zip" \
@@ -148,7 +148,8 @@ spec:
             ],
             \"description\": \"${description}\"
           };type=application/json"`
-      uuid=`echo ${upload#*= } | cut -d " " -f1`
+      uuid=${upload#*\"id\":\"}
+      uuid=${uuid%%\"*}
       getid=`curl -k -X GET "${url}/api/v1/${project}/launch/uuid/${uuid}" \
           -H "accept: */*" -H  "Authorization: bearer ${token}"`
       launchId=`echo $getid | jq .id`


### PR DESCRIPTION
Reportportal instance upgrade to 5.15.0. The previous API no longer supports. 
Importing Junit XML test results needs to install the Junit plugin first, and use the new API for the Junit plugin. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated JUnit test import processing with enhanced response parsing for improved accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->