### PR TITLE
Update mapt to v0.12.1

### DIFF
--- a/crc-builder/tkn/crc-builder-arm64.yaml
+++ b/crc-builder/tkn/crc-builder-arm64.yaml
@@ -95,7 +95,7 @@ spec:
 
   steps:
     - name: provisioner
-      image: quay.io/redhat-developer/mapt:v0.9.6
+      image: quay.io/redhat-developer/mapt:v0.12.1
       volumeMounts:
         - name: az-credentials
           mountPath: /opt/credentials
@@ -207,7 +207,7 @@ spec:
           cpu: 250m
       timeout: 900m
     - name: decommission
-      image: quay.io/redhat-developer/mapt:v0.9.6
+      image: quay.io/redhat-developer/mapt:v0.12.1
       volumeMounts:
         - name: az-credentials
           mountPath: /opt/credentials

--- a/crc-builder/tkn/tpl/crc-builder-arm64.tpl.yaml
+++ b/crc-builder/tkn/tpl/crc-builder-arm64.tpl.yaml
@@ -95,7 +95,7 @@ spec:
 
   steps:
     - name: provisioner
-      image: quay.io/redhat-developer/mapt:v0.9.6
+      image: quay.io/redhat-developer/mapt:v0.12.1
       volumeMounts:
         - name: az-credentials
           mountPath: /opt/credentials
@@ -207,7 +207,7 @@ spec:
           cpu: 250m
       timeout: 900m
     - name: decommission
-      image: quay.io/redhat-developer/mapt:v0.9.6
+      image: quay.io/redhat-developer/mapt:v0.12.1
       volumeMounts:
         - name: az-credentials
           mountPath: /opt/credentials

--- a/pipelines/crc-qe-latest-arm64.yaml
+++ b/pipelines/crc-qe-latest-arm64.yaml
@@ -151,7 +151,7 @@ spec:
           - name: url
             value: https://github.com/redhat-developer/mapt.git
           - name: revision
-            value: v0.9.7
+            value: v0.12.1
           - name: pathInRepo
             value: tkn/infra-aws-fedora.yaml
       params:
@@ -397,7 +397,7 @@ spec:
           - name: url
             value: https://github.com/redhat-developer/mapt.git
           - name: revision
-            value: v0.9.7
+            value: v0.12.1
           - name: pathInRepo
             value: tkn/infra-aws-fedora.yaml
       params:

--- a/pipelines/crc-qe-virtual-fedora.yaml
+++ b/pipelines/crc-qe-virtual-fedora.yaml
@@ -53,7 +53,7 @@ spec:
           - name: url
             value: https://github.com/redhat-developer/mapt
           - name: revision
-            value: v0.9.7
+            value: v0.12.1
           - name: pathInRepo
             value: tkn/infra-aws-fedora.yaml
       params:
@@ -185,7 +185,7 @@ spec:
           - name: url
             value: https://github.com/redhat-developer/mapt
           - name: revision
-            value: v0.9.7
+            value: v0.12.1
           - name: pathInRepo
             value: tkn/infra-aws-fedora.yaml
       params:

--- a/snc-runner/tkn/pipeline.yaml
+++ b/snc-runner/tkn/pipeline.yaml
@@ -119,7 +119,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: quay.io/redhat-developer/mapt:v0.9.9-tkn
+            value: quay.io/redhat-developer/mapt:v0.12.1-tkn
           - name: name
             value: infra-aws-rhel
           - name: kind
@@ -264,7 +264,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: quay.io/redhat-developer/mapt:v0.9.9-tkn
+            value: quay.io/redhat-developer/mapt:v0.12.1-tkn
           - name: name
             value: infra-aws-rhel
           - name: kind
@@ -318,7 +318,7 @@ spec:
                   resolver: bundles
                   params:
                     - name: bundle
-                      value: quay.io/redhat-developer/mapt:v0.9.9-tkn
+                      value: quay.io/redhat-developer/mapt:v0.12.1-tkn
                     - name: pathInRepo
                       value: tkn/infra-aws-rhel.yaml
                     - name: kind

--- a/snc-runner/tkn/tpl/pipeline.tpl.yaml
+++ b/snc-runner/tkn/tpl/pipeline.tpl.yaml
@@ -119,7 +119,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: quay.io/redhat-developer/mapt:v0.9.9-tkn
+            value: quay.io/redhat-developer/mapt:v0.12.1-tkn
           - name: name
             value: infra-aws-rhel
           - name: kind
@@ -264,7 +264,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: quay.io/redhat-developer/mapt:v0.9.9-tkn
+            value: quay.io/redhat-developer/mapt:v0.12.1-tkn
           - name: name
             value: infra-aws-rhel
           - name: kind
@@ -318,7 +318,7 @@ spec:
                   resolver: bundles
                   params:
                     - name: bundle
-                      value: quay.io/redhat-developer/mapt:v0.9.9-tkn
+                      value: quay.io/redhat-developer/mapt:v0.12.1-tkn
                     - name: pathInRepo
                       value: tkn/infra-aws-rhel.yaml
                     - name: kind


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded infrastructure provisioning and decommissioning tooling versions across CRC builder, QE pipeline, and SNC runner configurations to the latest stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->