### PR TITLE
Add custom disk size and integration memory params to pipelines

### DIFF
--- a/crc-e2e/qe-pvc.yaml
+++ b/crc-e2e/qe-pvc.yaml
@@ -103,7 +103,10 @@ spec:
       default: e2e-junit.xml
     - name: e2e-custom-memory
       description: If we want to customize the base memory to run the e2e we can set this value
-      default: "''"  
+      default: "''"
+    - name: e2e-custom-disk
+      description: If we want to customize the disk size to run the e2e we can set this value
+      default: "''"
     - name: e2e-cleanup-target
       description: To cleanup remote folder after running e2e
       default: "true"  
@@ -111,8 +114,14 @@ spec:
       description: Control if integration tests are executed. (true or false)
       default: 'true'
     - name: integration-tag
-      description: tags to select integration scenarios. Default empty values which means all scnearios  
-      default: "''"  
+      description: tags to select integration scenarios. Default empty values which means all scnearios
+      default: "''"
+    - name: integration-custom-memory
+      description: If we want to customize the base memory to run the integration we can set this value
+      default: "''"
+    - name: integration-custom-disk
+      description: If we want to customize the disk size to run the integration we can set this value
+      default: "''"
     - name: integration-timeout
       description: total timeout for run integration suite
       default: "90m"  
@@ -198,6 +207,9 @@ spec:
           fi
           if [[ $(params.e2e-custom-memory) != "" ]]; then
             cmd="$cmd -crcMemory $(params.e2e-custom-memory) "
+          fi
+          if [[ $(params.e2e-custom-disk) != "" ]]; then
+            cmd="$cmd -crcDiskSize $(params.e2e-custom-disk) "
           fi
         
           # Exec
@@ -292,6 +304,12 @@ spec:
           fi
           if [[ "$(params.integration-tag)" != "" ]]; then
             cmd="$cmd -labelFilter '$(params.integration-tag)' "
+          fi
+          if [[ $(params.integration-custom-memory) != "" ]]; then
+            cmd="$cmd -crcMemory $(params.integration-custom-memory) "
+          fi
+          if [[ $(params.integration-custom-disk) != "" ]]; then
+            cmd="$cmd -crcDiskSize $(params.integration-custom-disk) "
           fi
           
           # Exec

--- a/pipelines/crc-qe-latest-arm64.yaml
+++ b/pipelines/crc-qe-latest-arm64.yaml
@@ -63,7 +63,19 @@ spec:
     - name: integration-timeout
       description: total timeout for run integration suite
       default: "120m"
-    
+    - name: e2e-custom-memory
+      description: If we want to customize the base memory to run the e2e we can set this value
+      default: "''"
+    - name: e2e-custom-disk
+      description: If we want to customize the disk size to run the e2e we can set this value
+      default: "''"
+    - name: integration-custom-memory
+      description: If we want to customize the base memory to run the integration we can set this value
+      default: "''"
+    - name: integration-custom-disk
+      description: If we want to customize the disk size to run the integration we can set this value
+      default: "''"
+
     # Control
     - name: debug
       description: debug the task cmds
@@ -332,9 +344,17 @@ spec:
         value: $(params.target-cleanup) 
       - name: integration-timeout
         value: $(params.integration-timeout)
+      - name: e2e-custom-memory
+        value: $(params.e2e-custom-memory)
+      - name: e2e-custom-disk
+        value: $(params.e2e-custom-disk)
+      - name: integration-custom-memory
+        value: $(params.integration-custom-memory)
+      - name: integration-custom-disk
+        value: $(params.integration-custom-disk)
       - name: debug
-        value: $(params.debug) 
-      timeout: "5h"   
+        value: $(params.debug)
+      timeout: "5h"
     
     - name: s3-upload-results
       runAfter:

--- a/pipelines/crc-qe-latest.yaml
+++ b/pipelines/crc-qe-latest.yaml
@@ -101,6 +101,18 @@ spec:
     - name: integration-timeout
       description: total timeout for run integration suite
       default: "120m"
+    - name: e2e-custom-memory
+      description: If we want to customize the base memory to run the e2e we can set this value
+      default: "''"
+    - name: e2e-custom-disk
+      description: If we want to customize the disk size to run the e2e we can set this value
+      default: "''"
+    - name: integration-custom-memory
+      description: If we want to customize the base memory to run the integration we can set this value
+      default: "''"
+    - name: integration-custom-disk
+      description: If we want to customize the disk size to run the integration we can set this value
+      default: "''"
 
     # Control
     - name: debug
@@ -469,9 +481,17 @@ spec:
         value: $(params.target-cleanup) 
       - name: integration-timeout
         value: $(params.integration-timeout)
+      - name: e2e-custom-memory
+        value: $(params.e2e-custom-memory)
+      - name: e2e-custom-disk
+        value: $(params.e2e-custom-disk)
+      - name: integration-custom-memory
+        value: $(params.integration-custom-memory)
+      - name: integration-custom-disk
+        value: $(params.integration-custom-disk)
       - name: debug
         value: $(params.debug)
-      timeout: "5h" 
+      timeout: "5h"
     - name: s3-upload-results
       runAfter:
       - qe


### PR DESCRIPTION
Add e2e-custom-disk, integration-custom-memory and integration-custom-disk parameters to the qe task and both pipelines (amd64 and arm64). Also wire the existing e2e-custom-memory through the pipelines, which was defined on the task but never passed from the pipeline level.

depends on https://github.com/crc-org/crc/pull/5269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced customizable memory and disk sizing parameters for end-to-end and integration test execution pipelines. Testing workflows now support optional custom resource allocation, enabling more flexible configuration of test environments to accommodate varying performance requirements and infrastructure constraints across different testing scenarios and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->